### PR TITLE
Switch to DataStructures 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-DataStructures = "0.17"
+DataStructures = "0.18"
 DiffEqBase = "6.11"
 ForwardDiff = "0.10"
 NLsolve = "4.2"

--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module DiffEqCallbacks
 
   using DiffEqBase, RecursiveArrayTools, DataStructures, RecipesBase, StaticArrays,

--- a/src/function_caller.jl
+++ b/src/function_caller.jl
@@ -9,7 +9,7 @@ end
 
 function (affect!::FunctionCallingAffect)(integrator,force_func = false)
     # see OrdinaryDiffEq.jl -> integrator_utils.jl, function funcvalues!
-    while !isempty(affect!.funcat) && integrator.tdir*top(affect!.funcat) <= integrator.tdir*integrator.t # Perform funcat
+    while !isempty(affect!.funcat) && integrator.tdir * first(affect!.funcat) <= integrator.tdir * integrator.t # Perform funcat
         affect!.funciter += 1
         curt = pop!(affect!.funcat) # current time
         if curt != integrator.t # If <t, interpolate

--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -18,18 +18,19 @@ function IterativeCallback(time_choice, user_affect!,tType = Float64;
         tnew = time_choice(integrator)
         tnew === nothing && (tnext[] = tnew; return)
         tstops = integrator.opts.tstops
+        #=
+        Okay yeah, this is nasty
+        the comparer is always less than for type stability, so in order
+        for this to actually check the correct direction we multiply by
+        tdir
+        =#
+        tdir_tnew = integrator.tdir * tnew
         for i in length(tstops) : -1 : 1 # reverse iterate to encounter large elements earlier
-            #=
-            Okay yeah, this is nasty
-            the comparer is always less than for type stability, so in order
-            for this to actually check the correct direction we multiply by
-            tdir
-            =#
-            if DataStructures.compare(tstops.comparer, integrator.tdir*tnew, integrator.tdir*tstops.valtree[i]) # TODO: relying on implementation details
+            if tdir_tnew < tstops.valtree[i] # TODO: relying on implementation details
                 tnext[] = tnew
                 add_tstop!(integrator, tnew)
                 break
-            elseif tstops.valtree[i] == tnew
+            elseif tdir_tnew == tstops.valtree[i]
               # If it's already a tstop, no need to re-add! This is for the final point
               tnext[] = tnew
             end
@@ -72,14 +73,15 @@ function PeriodicCallback(f, Δt::Number;
         # Schedule next call to `f` using `add_tstops!`, but be careful not to keep integrating forever
         tnew = t0[] + (index[] + 1) * Δt
         tstops = integrator.opts.tstops
+        #=
+        Okay yeah, this is nasty
+        the comparer is always less than for type stability, so in order
+        for this to actually check the correct direction we multiply by
+        tdir
+        =#
+        tdir_tnew = integrator.tdir * tnew
         for i in length(tstops) : -1 : 1 # reverse iterate to encounter large elements earlier
-            #=
-            Okay yeah, this is nasty
-            the comparer is always less than for type stability, so in order
-            for this to actually check the correct direction we multiply by
-            tdir
-            =#
-            if DataStructures.compare(tstops.comparer, integrator.tdir*tnew, integrator.tdir*tstops.valtree[i]) # TODO: relying on implementation details
+            if tdir_tnew < tstops.valtree[i] # TODO: relying on implementation details
                 index[] += 1
                 add_tstop!(integrator, tnew)
                 break

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -45,7 +45,7 @@ function (affect!::SavingAffect)(integrator,force_save = false)
 
     just_saved = false
     # see OrdinaryDiffEq.jl -> integrator_utils.jl, function savevalues!
-    while !isempty(affect!.saveat) && integrator.tdir*top(affect!.saveat) <= integrator.tdir*integrator.t # Perform saveat
+    while !isempty(affect!.saveat) && integrator.tdir * first(affect!.saveat) <= integrator.tdir * integrator.t # Perform saveat
         affect!.saveiter += 1
         curt = pop!(affect!.saveat) # current time
         if curt != integrator.t # If <t, interpolate


### PR DESCRIPTION
This requires some additional changes since also internal orderings and comparisons were switched to `Base.Order`. I replaced these checks with the same comparisons as used throughout OrdinaryDiffEq etc. (e.g., https://github.com/SciML/OrdinaryDiffEq.jl/blob/7bd3338ac409b550743e3ceed745dad1186adfa8/src/iterator_interface.jl#L3) - this also changes the logic of the comparisons (`valtree[i]` is not multiplied with `tdir` anymore) but is consistent with other packages. Hence I assume that there might be some bug here currently.

Unfortunately tests fail due to, e.g., OrdinaryDiffEq not being compatible with DataStructures 0.18.