### PR TITLE
Vectorize condition in favor of GPU efficiency

### DIFF
--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -15,8 +15,7 @@ function allDerivPass(integrator, abstol, reltol)
         end
     end
 
-    any(abs(d) > abstol && abs(d) > reltol*abs(u) for (d,abstol, reltol, u) =
-           zip(testval, Iterators.cycle(abstol), Iterators.cycle(reltol), integrator.u)) && (return false)
+    any((abs.(testval) .> abstol) .& (abs.(testval) .> reltol .* abs.(integrator.u))) && (return false)
     return true
 end
 

--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -15,7 +15,12 @@ function allDerivPass(integrator, abstol, reltol)
         end
     end
 
-    any((abs.(testval) .> abstol) .& (abs.(testval) .> reltol .* abs.(integrator.u))) && (return false)
+    if typeof(integrator.u) <: Array
+        any(abs(d) > abstol && abs(d) > reltol*abs(u) for (d,abstol, reltol, u) =
+           zip(testval, Iterators.cycle(abstol), Iterators.cycle(reltol), integrator.u)) && (return false)
+    else
+        any((abs.(testval) .> abstol) .& (abs.(testval) .> reltol .* abs.(integrator.u))) && (return false)
+    end
     return true
 end
 


### PR DESCRIPTION
I realize this partially undoes a change in https://github.com/SciML/DiffEqCallbacks.jl/pull/35 , and will be less efficient in CPU in many situations. But I don't realize any other way to make this GPU-friendly.

The best compromise solution would be some reduce function with an "early return", both in CPU and GPU, but I couldn't find any implementation.

