### PR TITLE
PeriodicCallback default argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ PeriodicCallback(f, Δt::Number; initial_affect = true, kwargs...)
 ```
 
 where `f` is the function to be called periodically, `Δt` is the period, `initial_affect` is whether to apply
-the affect at `t=0` which defaults to `true`, and `kwargs` are keyword arguments accepted by the `DiscreteCallback` constructor.
+the affect at `t=0` which defaults to `false`, and `kwargs` are keyword arguments accepted by the `DiscreteCallback` constructor.
 
 ## TerminateSteadyState
 


### PR DESCRIPTION
It is `false` in the code. Closes https://github.com/SciML/DiffEqCallbacks.jl/issues/97.