### PR TITLE
Move OrdinaryDiffEq to test dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -21,7 +20,6 @@ DataStructures = "0.18"
 DiffEqBase = "6.11"
 ForwardDiff = "0.10"
 NLsolve = "4.2"
-OrdinaryDiffEq = "5.13, 6"
 Parameters = "0.12"
 RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "2"
@@ -32,8 +30,9 @@ julia = "1.6"
 [extras]
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["DiffEqProblemLibrary", "Test", "DiffEqSensitivity", "Tracker"]
+test = ["OrdinaryDiffEq", "DiffEqProblemLibrary", "Test", "DiffEqSensitivity", "Tracker"]

--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -9,9 +9,6 @@ module DiffEqCallbacks
 
   import SciMLBase
 
-  import OrdinaryDiffEq
-  using OrdinaryDiffEq: ODEIntegrator
-
   include("autoabstol.jl")
   include("manifold.jl")
   include("domain.jl")

--- a/src/domain.jl
+++ b/src/domain.jl
@@ -61,9 +61,9 @@ function affect!(integrator, f::AbstractDomainAffect{T,S,uType}) where {T,S,uTyp
 
     # ensure that t + dt <= first(tstops)
     tdir = integrator.tdir
-    if OrdinaryDiffEq.has_tstop(integrator)
+    if SciMLBase.has_tstop(integrator)
         tdir_t = tdir * integrator.t
-        tdir_tstop = OrdinaryDiffEq.first_tstop(integrator)
+        tdir_tstop = SciMLBase.first_tstop(integrator)
         dt = tdir * min(abs(dt), abs(tdir_tstop - tdir_t)) # step! to the end
     end
     t = integrator.t + dt

--- a/src/function_caller.jl
+++ b/src/function_caller.jl
@@ -13,7 +13,7 @@ function (affect!::FunctionCallingAffect)(integrator,force_func = false)
         affect!.funciter += 1
         curt = pop!(affect!.funcat) # current time
         if curt != integrator.t # If <t, interpolate
-            if typeof(integrator) <: ODEIntegrator
+            if integrator isa SciMLBase.AbstractODEIntegrator
                 # Expand lazy dense for interpolation
                 DiffEqBase.addsteps!(integrator)
             end

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -49,7 +49,7 @@ function (affect!::SavingAffect)(integrator,force_save = false)
         affect!.saveiter += 1
         curt = pop!(affect!.saveat) # current time
         if curt != integrator.t # If <t, interpolate
-            if typeof(integrator) <: ODEIntegrator
+            if integrator isa SciMLBase.AbstractODEIntegrator
                 # Expand lazy dense for interpolation
                 DiffEqBase.addsteps!(integrator)
             end


### PR DESCRIPTION
*DiffEqCallbacks* actually don't use any essential OrdinaryDiffEq.jl parts in the package code, only in the tests.
The only part that came from *OrdinaryDiffEq.jl* were tstop utilities, but these probably belong to *DEIntegrator* API in *SciMLBase* together with `add_tstop!()` (this would be addressed by the PRs to the respective packages).
The original motivation for this PR was to reduce the dependency burden of one of my projects.

I think this refinement of dependencies breaks the sort-of circular loop in the dependency logic -- the callbacks should not be dependent on the actual implementation of the DE integration.
Plus in the long run it would help to better outline the API boundaries of *DEIntegrator*/*AbstractODEIntegrator* vs *ODEIntegrator*.


