### PR TITLE
Avoid adding `tstops` greater than final time

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -86,7 +86,11 @@ function (S::PeriodicCallbackAffect)(integrator)
 
     affect!(integrator)
 
-    tstops = integrator.opts.tstops
+    add_next_tstop!(integrator, S)
+end
+
+function add_next_tstop!(integrator, S)
+    @unpack Δt, t0, index = S
 
     # Schedule next call to `f` using `add_tstops!`, but be careful not to keep integrating forever
     tnew = t0[] + (index[] + 1) * Δt
@@ -98,12 +102,9 @@ function (S::PeriodicCallbackAffect)(integrator)
     tdir
     =#
     tdir_tnew = integrator.tdir * tnew
-    for i in length(tstops):-1:1 # reverse iterate to encounter large elements earlier
-        if tdir_tnew < tstops.valtree[i] # TODO: relying on implementation details
-            index[] += 1
-            add_tstop!(integrator, tnew)
-            break
-        end
+    if tdir_tnew < maximum(tstops.valtree)
+        index[] += 1
+        add_tstop!(integrator, tnew)
     end
 end
 
@@ -146,12 +147,11 @@ function PeriodicCallback(f, Δt::Number;
         @assert integrator.tdir == sign(Δt)
         initialize(c, u, t, integrator)
         t0[] = t
+        index[] = 0
         if initial_affect
-            index[] = 0
             affect!(integrator)
         else
-            index[] = 1
-            add_tstop!(integrator, t0[] + Δt)
+            add_next_tstop!(integrator, affect!)
         end
     end
 

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -73,3 +73,10 @@ p = nothing
 prob = ODEProblem(fff, u0, tspan, p)
 sol = solve(prob, Tsit5(), callback = cb)
 @test sol.u[2] == [2.0, 2.0]
+
+# Test that `Δt > tspan[2]` does not extend the simulation beyond `tspan[2]`
+# when `initial_affect = false`.
+cb = PeriodicCallback(periodic, 11.0, initial_affect = false)
+prob = ODEProblem(fff, u0, tspan, p)
+sol = solve(prob, Tsit5(), callback = cb)
+@test sol.t[end] == tspan[2]


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, DiffEqCallbacks

f(u, p, t) = 1.0

ode = ODEProblem(f, 0.0, (0.0, 1.0))

cb = PeriodicCallback(integrator -> nothing, 2.0)

sol = solve(ode, Euler(), dt=0.1, callback=cb);

sol.t[end]
```

Before, this returned `2.0`, thus extending the simulation beyond `tspan[2]`.