### PR TITLE
Add option `final_affect` to `PeriodicCallback`

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -120,11 +120,12 @@ discrete-time controller for a continuous-time system, running at a fixed rate.
 ## Arguments
 
 - `f` the `affect!(integrator)` function to be called periodically
-- `Δt` is the period, `initial_affect` is whether to apply the affect at `t=0` which
-  defaults to `false`
+- `Δt` is the period
 
 ## Keyword Arguments
 
+- `initial_affect` is whether to apply the affect at `t=0`, which defaults to `false`
+- `final_affect` is whether to apply the affect at the final time, which defaults to `false`
 - `kwargs` are keyword arguments accepted by the `DiscreteCallback` constructor.
 """
 function PeriodicCallback(f, Δt::Number;

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -73,3 +73,10 @@ p = nothing
 prob = ODEProblem(fff, u0, tspan, p)
 sol = solve(prob, Tsit5(), callback = cb)
 @test sol.u[2] == [2.0, 2.0]
+@test sol.u[end][1] != sol.u[end][2] # `final_affect = false` by default
+
+# Test that the callback is applied again when the simulation finished.
+cb = PeriodicCallback(periodic, 3.0, initial_affect = true, final_affect = true,
+                      save_positions = (true, true))
+sol = solve(prob, Tsit5(), callback = cb)
+@test sol.u[end][1] == sol.u[end][2]


### PR DESCRIPTION
This allows to additionally call the affect of the `PeriodicCallback` at the end of the simulation.