### PR TITLE
fix: Allow to terminate! in PeriodicCallback

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -84,9 +84,9 @@ end
 function (S::PeriodicCallbackAffect)(integrator)
     @unpack affect!, Δt, t0, index = S
 
-    affect!(integrator)
-
     add_next_tstop!(integrator, S)
+
+    affect!(integrator)
 end
 
 function add_next_tstop!(integrator, S)

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -81,6 +81,14 @@ cb = PeriodicCallback(periodic, 3.0, initial_affect = true, final_affect = true,
 sol = solve(prob, Tsit5(), callback = cb)
 @test sol.u[end][1] == sol.u[end][2]
 
+# Test a PeriodicCallback that stops the simulation with terminate!(integrator)
+periodic_terminate2 = integrator -> if integrator.t >= tmax; terminate!(integrator) end
+cb = PeriodicCallback(periodic_terminate2, 0.1, initial_affect = true, final_affect = true,
+                      save_positions = (true, true))
+sol = solve(prob, Tsit5(), callback = cb)
+@test sol.retcode == :Terminated
+@test sol.t[end] == tmax
+
 # Test that `Δt > tspan[2]` does not extend the simulation beyond `tspan[2]`
 # when `initial_affect = false`.
 cb = PeriodicCallback(periodic, 11.0, initial_affect = false)

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -86,7 +86,7 @@ periodic_terminate2 = integrator -> if integrator.t >= tmax; terminate!(integrat
 cb = PeriodicCallback(periodic_terminate2, 0.1, initial_affect = true, final_affect = true,
                       save_positions = (true, true))
 sol = solve(prob, Tsit5(), callback = cb)
-@test sol.retcode == :Terminated
+@test sol.retcode == ReturnCode.Terminated
 @test sol.t[end] == tmax
 
 # Test that `Δt > tspan[2]` does not extend the simulation beyond `tspan[2]`


### PR DESCRIPTION
This fix suggests inverting add_next_tstop! and affect! for PeriodicCallbacks. Solving issue #147 :)