### PR TITLE
fix docstring of PeriodicCallback

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -110,7 +110,9 @@ end
 
 """
 ```julia
-PeriodicCallback(f, Δt::Number; initial_affect = true, kwargs...)
+PeriodicCallback(f, Δt::Number; initial_affect = false, 
+                                final_affect = false,
+                                kwargs...)
 ```
 
 `PeriodicCallback` can be used when a function should be called periodically in terms of

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -82,7 +82,9 @@ sol = solve(prob, Tsit5(), callback = cb)
 @test sol.u[end][1] == sol.u[end][2]
 
 # Test a PeriodicCallback that stops the simulation with terminate!(integrator)
-periodic_terminate2 = integrator -> if integrator.t >= tmax; terminate!(integrator) end
+periodic_terminate2 = integrator -> if integrator.t >= tmax
+    terminate!(integrator)
+end
 cb = PeriodicCallback(periodic_terminate2, 0.1, initial_affect = true, final_affect = true,
                       save_positions = (true, true))
 sol = solve(prob, Tsit5(), callback = cb)


### PR DESCRIPTION
The docstring didn't match the implementation (of the default values).