### PR TITLE
Minor corretion of docstring for PeriodicCallback (initial_affect / default value)

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -110,7 +110,7 @@ end
 
 """
 ```julia
-PeriodicCallback(f, Δt::Number; initial_affect = true, kwargs...)
+PeriodicCallback(f, Δt::Number; initial_affect = false, kwargs...)
 ```
 
 `PeriodicCallback` can be used when a function should be called periodically in terms of


### PR DESCRIPTION
The default value of the keyword argument `initial_affect` in function PeriodicCallback was corrected.