### PR TITLE
fix output callback kwarg edge cases

### DIFF
--- a/src/function_caller.jl
+++ b/src/function_caller.jl
@@ -42,7 +42,12 @@ function functioncalling_initialize(cb, u, t, integrator)
         tspan = integrator.sol.prob.tspan
         funcat_cache = cb.affect!.funcat_cache
         funcat_vec = if funcat_cache isa Number
-            range(tspan...; step = funcat_cache)
+            step = funcat_cache
+            t0, tf = tspan
+            if !cb.affect!.func_start
+                t0 += step
+            end
+            range(t0, tf; step)
         else
             funcat_cache
         end
@@ -54,6 +59,7 @@ function functioncalling_initialize(cb, u, t, integrator)
         cb.affect!.funciter = 0
     end
     cb.affect!.func_start && cb.affect!(integrator)
+    u_modified!(integrator, false)
 end
 
 """

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -87,7 +87,15 @@ function saving_initialize(cb, u, t, integrator)
         tspan = integrator.sol.prob.tspan
         saveat_cache = cb.affect!.saveat_cache
         if saveat_cache isa Number
-            saveat_vec = range(tspan...; step = saveat_cache)
+            step = saveat_cache
+            t0, tf = tspan
+            if !cb.affect!.save_start
+                t0 += step
+            end
+            if !cb.affect!.save_end
+                tf -= step
+            end
+            saveat_vec = range(t0, tf; step)
             # avoid saving end twice
             if tspan[end] == last(saveat_vec)
                 cb.affect!.save_end = false
@@ -103,6 +111,7 @@ function saving_initialize(cb, u, t, integrator)
         cb.affect!.saveiter = 0
     end
     cb.affect!.save_start && cb.affect!(integrator)
+    u_modified!(integrator, false)
 end
 
 """
@@ -131,6 +140,7 @@ returns quantities of interest that shall be saved.
   - `saveat` mimics `saveat` in `solve` from `solve`.
   - `save_everystep` mimics `save_everystep` from `solve`.
   - `save_start` mimics `save_start` from `solve`.
+  - `save_end` mimics `save_end` from `solve`.
   - `tdir` should be `sign(tspan[end]-tspan[1])`. It defaults to `1` and should
     be adapted if `tspan[1] > tspan[end]`.
 

--- a/test/funccall_tests.jl
+++ b/test/funccall_tests.jl
@@ -18,6 +18,15 @@ sol = solve(prob, Tsit5(), callback = cb)
 @test collect(0.0:0.25:1.0) == ts
 
 ts = Vector{Float64}()
+cb = FunctionCallingCallback((u, t, integrator) -> push!(ts, t),
+    funcat = 0.25,
+    func_start = false)
+preset = PresetTimeCallback(Float64[], identity)
+sol = solve(prob, Tsit5(), callback = CallbackSet(cb, preset))
+@test collect(0.25:0.25:1.0) == ts
+@test sol.t[2] > 0
+
+ts = Vector{Float64}()
 cb = FunctionCallingCallback((u, t, integrator) -> push!(ts, t), funcat = 0.0:0.25:1.0,
     func_everystep = true)
 sol = solve(prob, Tsit5(), callback = cb)

--- a/test/saving_tests.jl
+++ b/test/saving_tests.jl
@@ -44,6 +44,18 @@ sol = solve(prob, Tsit5(), callback = cb)
 @test all(idx -> abs(sol(saveat[idx]) - saved_values.saveval[idx]) < 8.e-15,
     eachindex(saved_values.t))
 
+# scalar saveat without start and end
+saved_values = SavedValues(Float64, Float64)
+cb = SavingCallback((u, t, integrator) -> u,
+    saved_values;
+    saveat = 0.2,
+    save_start = false,
+    save_end = false)
+preset = PresetTimeCallback(Float64[], identity)
+sol = solve(prob, Tsit5(); dt = 0.2, adaptive = false, callback = CallbackSet(cb, preset))
+@test sol.t ≈ 0.0:0.2:1.0
+@test saved_values.t ≈ 0.2:0.2:0.8
+
 # saveat, inplace problem
 saved_values = SavedValues(eltype(prob2D.tspan), typeof(prob2D.u0))
 saveat = range(prob2D.tspan[1], stop = prob.tspan[2], length = 50)
@@ -95,7 +107,6 @@ saved_values = SavedValues(Float64, Tuple{Float64, Float64})
 cb = SavingCallback((u, t, integrator) -> (tr(u), norm(u)), saved_values,
     saveat = 0.0:0.1:1.0)
 sol = solve(prob, Tsit5(), callback = cb)
-println(saved_values.saveval)
 
 # Save only end
 prob = ODEProblem((du, u, p, t) -> du .= u, rand(4, 4), (0.0, 1.0))


### PR DESCRIPTION
If `save_start` was false, `u_modified` was not set to false for `SavingCallback` and `FunctionCallingCallback`. This led to a doubly saved t=0, but only when combined in a `CallbackSet`.

Furthermore we now properly support combining scalar saveat from #157 with excluding the start and/or end.

Test cases for both issues are included.
