### PR TITLE
more CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,36 +10,34 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '25 16 * * 4'
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
+        version:
+          - '1'
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        version:
-          - '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
+      - uses: julia-actions/cache@v1
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,7 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
+  schedule:
+    - cron: '25 16 * * 4'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,20 +10,32 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '25 16 * * 4'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        version: ['1']
+        group:
+          - Core
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
       - uses: cjdoris/julia-downgrade-compat-action@v1
-#        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg,TOML
+      - uses: julia-actions/cache@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,7 @@ Parameters = "0.12"
 QuadGK = "2.4"
 RecipesBase = "1.1"
 RecursiveArrayTools = "2.38, 3"
+SafeTestsets = "0.1"
 SciMLBase = "2.9"
 SciMLSensitivity = "7.49"
 StaticArrays = "1.8"
@@ -53,6 +54,7 @@ DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
@@ -61,5 +63,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "DataInterpolations", "OrdinaryDiffEq", "ODEProblemLibrary", "Test", "QuadGK", "SciMLSensitivity", "StaticArrays", "Tracker", "Zygote"]
-
+test = ["Aqua", "SafeTestsets", "DataInterpolations", "OrdinaryDiffEq", "ODEProblemLibrary", "Test", "QuadGK", "SciMLSensitivity", "StaticArrays", "Tracker", "Zygote"]

--- a/test/integrating_sum_tests.jl
+++ b/test/integrating_sum_tests.jl
@@ -1,3 +1,4 @@
+using DiffEqCallbacks
 using OrdinaryDiffEq, SciMLSensitivity, Zygote
 using ForwardDiff
 using QuadGK

--- a/test/integrating_tests.jl
+++ b/test/integrating_tests.jl
@@ -1,3 +1,4 @@
+using DiffEqCallbacks
 using OrdinaryDiffEq, SciMLSensitivity, Zygote
 using ForwardDiff
 using QuadGK

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,51 +1,17 @@
-using DiffEqCallbacks
-using Test
+using SafeTestsets, Test
 
-# write your own tests here
-@time begin
-    @time @testset "Quality Assurance" begin
-        include("qa.jl")
-    end
-    @time @testset "AutoAbstol" begin
-        include("autoabstol_tests.jl")
-    end
-    @time @testset "TerminateSteadyState tests" begin
-        include("terminatesteadystate_test.jl")
-    end
-    @time @testset "StepsizeLimiter tests" begin
-        include("stepsizelimiter_tests.jl")
-    end
-    @time @testset "Function Calling tests" begin
-        include("funccall_tests.jl")
-    end
-    @time @testset "IndependentlyLinearized tests" begin
-        include("independentlylinearizedtests.jl")
-    end
-    @time @testset "Saving tests" begin
-        include("saving_tests.jl")
-    end
-    @time @testset "PresetTime tests" begin
-        include("preset_time.jl")
-    end
-    @time @testset "Iterative tests" begin
-        include("iterative_tests.jl")
-    end
-    @time @testset "Periodic tests" begin
-        include("periodic_tests.jl")
-    end
-    @time @testset "Manifold tests" begin
-        include("manifold_tests.jl")
-    end
-    @time @testset "Domain tests" begin
-        include("domain_tests.jl")
-    end
-    @time @testset "ProbInts tests" begin
-        include("probints.jl")
-    end
-    @time @testset "Integrating tests" begin
-        include("integrating_tests.jl")
-    end
-    @time @testset "Integrating sum tests" begin
-        include("integrating_sum_tests.jl")
-    end
-end
+@time @safetestset "Quality Assurance" include("qa.jl")
+@time @safetestset "AutoAbstol" include("autoabstol_tests.jl")
+@time @safetestset "TerminateSteadyState tests" include("terminatesteadystate_test.jl")
+@time @safetestset "StepsizeLimiter tests" include("stepsizelimiter_tests.jl")
+@time @safetestset "Function Calling tests" include("funccall_tests.jl")
+@time @safetestset "IndependentlyLinearized tests" include("independentlylinearizedtests.jl")
+@time @safetestset "Saving tests" include("saving_tests.jl")
+@time @safetestset "PresetTime tests" include("preset_time.jl")
+@time @safetestset "Iterative tests" include("iterative_tests.jl")
+@time @safetestset "Periodic tests" include("periodic_tests.jl")
+@time @safetestset "Manifold tests" include("manifold_tests.jl")
+@time @safetestset "Domain tests" include("domain_tests.jl")
+@time @safetestset "ProbInts tests" include("probints.jl")
+@time @safetestset "Integrating tests" include("integrating_tests.jl")
+@time @safetestset "Integrating sum tests" include("integrating_sum_tests.jl")


### PR DESCRIPTION
RAT deprecation message is incorrect here for the manifold tests.

```jl
julia> sol[88]
┌ Warning: `Base.getindex(A::AbstractDiffEqArray, i::Int)` is deprecated, use `Base.getindex(A, :, i)` instead.
│   caller = top-level scope at REPL[26]:1
└ @ Core REPL[26]:1
2×2 Matrix{Float64}:
 0.355718  0.355718
 1.36903   1.36903

julia> sol[end]
┌ Warning: Linear indexing of `AbstractVectorOfArray` is deprecated. Change `A[i]` to `A.u[i]`
│   caller = top-level scope at REPL[27]:1
└ @ Core REPL[27]:1
┌ Warning: `Base.getindex(A::AbstractDiffEqArray, i::Int)` is deprecated, use `Base.getindex(A, :, i)` instead.
│   caller = top-level scope at REPL[27]:1
└ @ Core REPL[27]:1
2×2 Matrix{Float64}:
 0.355718  0.355718
 1.36903   1.36903

julia> sol[:,88]
2×2 Matrix{Float64}:
 0.355718  0.355718
 1.36903   1.36903

julia> sol[:,end]
2×2 Matrix{Float64}:
 1.17331   1.17331
 0.789515  0.789515
```