### PR TITLE
Fail with grace with the ILS after initialization failure

### DIFF
--- a/src/saving.jl
+++ b/src/saving.jl
@@ -433,7 +433,10 @@ function LinearizingSavingCallback(ils::IndependentlyLinearizedSolution{T,S};
         end,
         # We need to finalize the ils and free our caches
         finalize = (c, u, t, integ) -> begin
-            finish!(ils)
+            # Don't run the `finish!` if ils is in an inconsistent state
+            if check_error(integ) != ReturnCode.InitialFailure
+                finish!(ils)
+            end
             caches = nothing
         end,
         # Don't add tstops to the left and right.

--- a/test/saving_tests.jl
+++ b/test/saving_tests.jl
@@ -220,6 +220,22 @@ if VERSION >= v"1.9" # stack
         end
     end
 
+
+    @testset "fail gracefully" begin
+        f_error2(du, u, p, t) = du .= u ./ t .- 1
+        u0 = [1.0];
+        du0 = [1.0];
+        prob = DAEProblem(f_error2, u0, du0, (0.0, 1.0); differential_vars = [true])
+        ils = IndependentlyLinearizedSolution(unstable_prob, 0)
+        lsc = LinearizingSavingCallback(ils)
+        sol = solve(prob, DFBDF(); callback = lsc)  # this would if we were not failing with grace
+        @test sol.retcode == ReturnCode.InitialFailure
+        @test isempty(ils.ts)
+        @test isempty(ils.us)
+        @test isempty(ils.time_mask)
+    end
+    
+
     # We do not support 2d states yet.
     #test_linearization(prob_ode_2Dlinear, Tsit5())
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Without this change the test fails with
```
ERROR: ArgumentError: `length(ts)` must equal `size(time_mask, 2)`
Stacktrace:
  [1] finish!(ils::IndependentlyLinearizedSolution{Float64, Float64})
    @ DiffEqCallbacks ~/JuliaEnvs/CedarEDA.jl/dev/DiffEqCallbacks/src/independentlylinearizedutils.jl:227
  [2] #64
    @ ~/JuliaEnvs/CedarEDA.jl/dev/DiffEqCallbacks/src/saving.jl:438 [inlined]
  [3] finalize!
    @ ~/.julia/packages/DiffEqBase/UoaYd/src/callbacks.jl:38 [inlined]
  [4] finalize!
    @ ~/.julia/packages/DiffEqBase/UoaYd/src/callbacks.jl:28 [inlined]
  [5] _postamble!(integrator::OrdinaryDiffEq.ODEIntegrator{…})
    @ OrdinaryDiffEq ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/integrators/integrator_utils.jl:152
  [6] postamble!
    @ ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/integrators/integrator_utils.jl:149 [inlined]
  [7] check_error!
    @ ~/.julia/packages/SciMLBase/QSc1r/src/integrator_interface.jl:630 [inlined]
  [8] solve!(integrator::OrdinaryDiffEq.ODEIntegrator{…})
    @ OrdinaryDiffEq ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/solve.jl:535
  [9] #__solve#749
    @ ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/solve.jl:6 [inlined]
 [10] __solve
    @ ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/solve.jl:1 [inlined]
 [11] solve_call(_prob::DAEProblem{…}, args::DFBDF{…}; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/UoaYd/src/solve.jl:609
 [12] solve_up(prob::DAEProblem{…}, sensealg::Nothing, u0::Vector{…}, p::SciMLBase.NullParameters, args::DFBDF{…}; kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/UoaYd/src/solve.jl:1058
 [13] solve(prob::DAEProblem{…}, args::DFBDF{…}; sensealg::Nothing, u0::Nothing, p::Nothing, wrap::Val{…}, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/UoaYd/src/solve.jl:981
 [14] top-level scope
    @ REPL[44]:1
Some type information was truncated. Use `show(err)` to see complete types.
```


On Slack @ChrisRackauckas  said that the callback's finish shouldn't even be being called in this circumstance.
but idk if i described the circumstance right.
It seems a intentional feature of  `check_errors!` that it does this