### PR TITLE
remove complication from PresetTimeCallback

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -53,7 +53,8 @@ function PresetTimeCallback(tstops, user_affect!;
 
         if filter_tstops
             tdir = integrator.tdir
-            _tstops = tstops[@. tdir * integrator.sol.prob.tspan[1]) <= tdir * tstops < tdir * integrator.sol.prob.tspan[2]]
+            tspan = integrator.sol.prob.tspan
+            _tstops = tstops[@. tdir * tspan[1] <= tdir * tstops < tdir * tspan[2]]
             add_tstop!.((integrator,), _tstops)
         else
             add_tstop!.((integrator,), tstops)

--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -31,11 +31,11 @@ function PresetTimeCallback(tstops, user_affect!;
             tstops = sort(tstops)
         end
         condition = function (u, t, integrator)
-            insorted(t, tstops)
+            insorted(t, tstops) && (integrator.t - integrator.dt) != integrator.t
         end
     elseif tstops isa Number
         condition = function (u, t, integrator)
-            t == tstops
+            t == tstops && (integrator.t - integrator.dt) != integrator.t
         end
     else
         throw(ArgumentError("tstops must either be a number or a Vector. Was $tstops"))

--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -24,63 +24,42 @@ function PresetTimeCallback(tstops, user_affect!;
         initialize = SciMLBase.INITIALIZE_DEFAULT,
         filter_tstops = true,
         sort_inplace = false, kwargs...)
-    local tdir
     if tstops isa AbstractVector
         if sort_inplace
             sort!(tstops)
         else
             tstops = sort(tstops)
         end
-        search_start, search_end = firstindex(tstops), lastindex(tstops)
         condition = function (u, t, integrator)
-            t in @view(tstops[search_start:search_end])
+            insorted(t, tstops)
         end
-    else
-        search_start, search_end = 0, 0
+    elseif tstops isa Number
         condition = function (u, t, integrator)
             t == tstops
         end
+    else
+        throw(ArgumentError("tstops must either be a number or a Vector. Was $tstops"))
     end
 
     # Call f, update tnext, and make sure we stop at the new tnext
     affect! = function (integrator)
         user_affect!(integrator)
-        if integrator.tdir > 0
-            search_start += 1
-        else
-            search_end -= 1
-        end
         nothing
     end
 
     # Initialization: first call to `f` should be *before* any time steps have been taken:
     initialize_preset = function (c, u, t, integrator)
         initialize(c, u, t, integrator)
-        if tstops isa AbstractVector
-            search_start, search_end = firstindex(tstops), lastindex(tstops)
-        else
-            search_start, search_end = 0, 0
-        end
 
         if filter_tstops
             tdir = integrator.tdir
-            _tstops = tstops[@.((tdir * tstops >
-                                 tdir *
-                                 integrator.sol.prob.tspan[1])*(tdir *
-                                                                tstops <
-                                                                tdir *
-                                                                integrator.sol.prob.tspan[2]))]
+            _tstops = tstops[@. tdir * integrator.sol.prob.tspan[1]) <= tdir * tstops < tdir * integrator.sol.prob.tspan[2]]
             add_tstop!.((integrator,), _tstops)
         else
             add_tstop!.((integrator,), tstops)
         end
         if t ∈ tstops
             user_affect!(integrator)
-            if integrator.tdir > 0
-                search_start += 1
-            else
-                search_end -= 1
-            end
         end
     end
     DiscreteCallback(condition, affect!; initialize = initialize_preset, kwargs...)


### PR DESCRIPTION
Previously this code was doing some fairly weird stuff with the closures relying on indices being passed around in spooky ways. This was (I believe) intended as an optimization, but was confusing both me and the compiler, so I deleted it, and am replacing the in calls with `insorted` to make it faster.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
