### PR TITLE
PresetTimeCallback: filter out tstop of 0.0

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -62,7 +62,7 @@ function PresetTimeCallback(tstops, user_affect!;
         if filter_tstops
             tdir = integrator.tdir
             tspan = integrator.sol.prob.tspan
-            _tstops = tstops[@. tdir * tspan[1] <= tdir * tstops < tdir * tspan[2]]
+            _tstops = tstops[@. tdir * tspan[1] < tdir * tstops < tdir * tspan[2]]
             add_tstop!.((integrator,), _tstops)
         else
             add_tstop!.((integrator,), tstops)

--- a/test/preset_time.jl
+++ b/test/preset_time.jl
@@ -25,8 +25,11 @@ p = rand(4, 4)
 startp = copy(p)
 
 prob = ODEProblem(some_dynamics, u0, tspan, p)
-cb = PresetTimeCallback([0.3, 0.6], integrator -> integrator.p .= rand(4, 4))
-sol = solve(prob, Tsit5(), callback = cb)
+cb = PresetTimeCallback([0.0, 0.3, 0.6], integrator -> integrator.p .= rand(4, 4))
+integrator = init(prob, Tsit5(), callback = cb)
+@test first_tstop(integrator) == 0.3
+solve!(integrator)
+sol = integrator.sol
 @test 0.3 ∈ sol.t
 @test 0.6 ∈ sol.t
 @test p != startp


### PR DESCRIPTION
In #212 the behavior of `filter_tstops` was changed, note that the `<` became a `<=`.

https://github.com/SciML/DiffEqCallbacks.jl/pull/212/files#diff-40390d05d98d137d2045d5d61bdf194384f4e70b8778170c7d8af50143406d76R54-R57

I'm not sure if that was done intentionally but it is causing some issues. For instance, in the modified test from this PR, calling `solve!(integrator)` still works, but if I do `step!(integrator)` it aborts because it wants to step from 0 to 0.

```
Warning: dt(0.0) <= dtmin(0.0) at t=0.0, and step error estimate = 1.0. Aborting. There is either an error in your model specification or the true solution is unstable.
```