### PR TITLE
fix remaining allocations in `PresetTimeCallback`

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -30,7 +30,7 @@ function PresetTimeCallback(tstops, user_affect!;
         else
             tstops = sort(tstops)
         end
-        condition = let tstops=tstops
+        condition = let tstops = tstops
             function (u, t, integrator)
                 if hasproperty(integrator, :dt)
                     insorted(t, tstops) && (integrator.t - integrator.dt) != integrator.t
@@ -40,7 +40,7 @@ function PresetTimeCallback(tstops, user_affect!;
             end
         end
     elseif tstops isa Number
-        condition = let tstops=tstops
+        condition = let tstops = tstops
             function (u, t, integrator)
                 if hasproperty(integrator, :dt)
                     t == tstops && (integrator.t - integrator.dt) != integrator.t

--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -30,19 +30,23 @@ function PresetTimeCallback(tstops, user_affect!;
         else
             tstops = sort(tstops)
         end
-        condition = function (u, t, integrator)
-            if hasproperty(integrator, :dt)
-                insorted(t, tstops) && (integrator.t - integrator.dt) != integrator.t
-            else
-                insorted(t, tstops)
+        condition = let tstops=tstops
+            function (u, t, integrator)
+                if hasproperty(integrator, :dt)
+                    insorted(t, tstops) && (integrator.t - integrator.dt) != integrator.t
+                else
+                    insorted(t, tstops)
+                end
             end
         end
     elseif tstops isa Number
-        condition = function (u, t, integrator)
-            if hasproperty(integrator, :dt)
-                t == tstops && (integrator.t - integrator.dt) != integrator.t
-            else
-                t == tstops
+        condition = let tstops=tstops
+            function (u, t, integrator)
+                if hasproperty(integrator, :dt)
+                    t == tstops && (integrator.t - integrator.dt) != integrator.t
+                else
+                    t == tstops
+                end
             end
         end
     else


### PR DESCRIPTION
I was missing a `let` that was causing `tstops` to be captured by the `condition` closure. Fixes https://github.com/SciML/DiffEqCallbacks.jl/issues/217. We now get
```
julia> @time solve(prob, Tsit5(), callback=callback);
  0.000988 seconds (95 allocations: 44.703 KiB)
```
where all the additional allocations are in the `init` stage.