### PR TITLE
Fix type instability in `PresetTimeCallback` 

### DIFF
--- a/test/preset_time.jl
+++ b/test/preset_time.jl
@@ -89,3 +89,6 @@ sol2 = solve(prob2, Tsit5(), callback = cb1)
 @test sol2(0.0) == [10.0]
 @test sol2(24.0 + eps(24.0)) ≈ [10.0]
 @test sol2(48.0 + eps(48.0)) ≈ [10.0]
+
+_some_test_func(integrator) = u_modified!(integrator, false)
+@inferred PresetTimeCallback(collect(range(0, 10, 100)), _some_test_func, save_positions=(false, false))


### PR DESCRIPTION
close #225

This PR tries to solve the type instability in `PresetTimeCallback` start from `v3.2.0+`

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
