### PR TITLE
improve PresetTimeCallback

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -33,7 +33,7 @@ function PresetTimeCallback(tstops, user_affect!;
     condition = let
         function (u, t, integrator)
             if hasproperty(integrator, :dt)
-                insorted(t, tstops) && !iszero(integrator.dt)
+                insorted(t, tstops) && (integrator.t - integrator.dt) != integrator.t
             else
                 insorted(t, tstops)
             end

--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -28,7 +28,7 @@ function PresetTimeCallback(tstops, user_affect!;
         throw(ArgumentError("tstops must either be a number or a Vector. Was $tstops"))
     end
 
-    tstops = sort_inplace ? sort!(tstops) : sort(tstops)
+    tstops = tstops isa Number ? [tstops] : (sort_inplace ? sort!(tstops) : sort(tstops))
 
     condition = let
         function (u, t, integrator)
@@ -57,7 +57,7 @@ function PresetTimeCallback(tstops, user_affect!;
         else
             _tstops = tstops
         end
-        for tstop in tstops
+        for tstop in _tstops
             add_tstop!(integrator, tstop)
         end
         if t ∈ tstops


### PR DESCRIPTION
This PR removes spurious memory allocations of `PresetTimeCallback`.

I tried to run the test locally, but I got

```julia-repl
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations ~/.julia/juliaup/julia-1.11.0+0.x64.linux.gnu/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:1900
ERROR: Unsatisfiable requirements detected for package SciMLSensitivity [1ed8b502]:
 SciMLSensitivity [1ed8b502] log:
 ├─possible versions are: 7.0.0 - 7.68.0 or uninstalled
 ├─restricted to versions 7.68.0 - 7 by an explicit requirement, leaving only versions: 7.68.0
 └─restricted by compatibility requirements with DiffEqCallbacks [459566f4] to versions: uninstalled — no versions left
   └─DiffEqCallbacks [459566f4] log:
     ├─possible versions are: 4.0.0 or uninstalled
     └─DiffEqCallbacks [459566f4] is fixed to version 4.0.0
```

with both Julia 1.10 and 1.11.

This error shouldn't be related to this changes.