### PR TITLE
Simplify definition of `affect!` function in `PresetTimeCallback`

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -40,12 +40,6 @@ function PresetTimeCallback(tstops, user_affect!;
         end
     end
 
-    # Call f, update tnext, and make sure we stop at the new tnext
-    affect! = function (integrator)
-        user_affect!(integrator)
-        nothing
-    end
-
     # Initialization: first call to `f` should be *before* any time steps have been taken:
     initialize_preset = function (c, u, t, integrator)
         initialize(c, u, t, integrator)
@@ -64,7 +58,7 @@ function PresetTimeCallback(tstops, user_affect!;
             user_affect!(integrator)
         end
     end
-    DiscreteCallback(condition, affect!; initialize = initialize_preset, kwargs...)
+    DiscreteCallback(condition, user_affect!; initialize = initialize_preset, kwargs...)
 end
 
 export PresetTimeCallback


### PR DESCRIPTION
The current implementation of `PresetTimeCallback` defines the `user_affect!` function by passing through an intermediate function. Here I remove that unnecessary intermediate step. This would support custom `affect!` functions, for example formed by a strcut rather than a simple function.