### PR TITLE
allow for do syntax in `PresetTimeCallback`

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -4,6 +4,8 @@ PresetTimeCallback(tstops, user_affect!;
     initialize = DiffEqBase.INITIALIZE_DEFAULT,
     filter_tstops = true,
     kwargs...)
+
+PresetTimeCallback(user_affect!::Function, tstops; kwargs...)
 ```
 
 A callback that adds callback `affect!` calls at preset times. No playing around with
@@ -60,5 +62,7 @@ function PresetTimeCallback(tstops, user_affect!;
     end
     DiscreteCallback(condition, user_affect!; initialize = initialize_preset, kwargs...)
 end
+
+PresetTimeCallback(affect!::Function, ts; kwargs...) = PresetTimeCallback(ts, affect!; kwargs...)
 
 export PresetTimeCallback

--- a/test/preset_time.jl
+++ b/test/preset_time.jl
@@ -21,6 +21,15 @@ sol = solve(prob, Tsit5(), callback = cb)
 @test 0.5 ∈ sol.t
 @test p != startp
 
+# test do synax
+p .= startp # reset startp
+cbdoo = PresetTimeCallback(0.5) do integrator
+    integrator.p .= rand(4, 4)
+end
+sol = solve(prob, Tsit5(), callback = cbdoo)
+@test 0.5 ∈ sol.t
+@test p != startp
+
 p = rand(4, 4)
 startp = copy(p)
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Very often `PresetTimecallbacks` are fairly simple. Therefore it would be nice if the `affect` could be defined using do-syntax
```julia
cb = PresetTimeCallback([1.0]) do integrator
    @info "You've reached t=$(integrator.t). Hurray"
end
```

which, at least to me, is preferrable to the equivalent
```julia
cb = PresetTimeCallback([1.0], integrator -> begin
    @info "You've reached t=$(integrator.t). Hurray"
end)
```