### PR TITLE
Initialize line split fixes following Catalyst.jl PR #1306

### DIFF
--- a/src/integrating.jl
+++ b/src/integrating.jl
@@ -173,8 +173,7 @@ function (affect!::SavingIntegrandAffect)(integrator)
     end
     accumulation_cache = recursive_zero!(affect!.accumulation_cache)
     for i in 1:n
-        t_temp = ((integrator.t - integrator.tprev) / 2) * gauss_points[n][i] +
-                 (integrator.t + integrator.tprev) / 2
+        t_temp = ((integrator.t - integrator.tprev) / 2) * gauss_points[n][i] + (integrator.t + integrator.tprev) / 2
         if DiffEqBase.isinplace(integrator.sol.prob)
             curu = first(get_tmp_cache(integrator))
             integrator(curu, t_temp)

--- a/src/integrating_GK_affect.jl
+++ b/src/integrating_GK_affect.jl
@@ -152,8 +152,7 @@ function integrate_gk!(affect!::SavingIntegrandGKAffect, integrator,
             end
         end
     end
-    if sum(abs.((affect!.gk_step_cache .- affect!.gk_err_cache) .* (bound_r-bound_l) ./
-                2))<tol
+    if sum(abs.((affect!.gk_step_cache .- affect!.gk_err_cache) .* (bound_r-bound_l) ./ 2))<tol
         recursive_axpy!(1, affect!.gk_step_cache .* (bound_r-bound_l) ./ 2, affect!.accumulation_cache)
     else
         integrate_gk!(

--- a/src/integrating_GK_sum.jl
+++ b/src/integrating_GK_sum.jl
@@ -46,8 +46,7 @@ function integrate_gk!(affect!::SavingIntegrandGKSumAffect, integrator,
             end
         end
     end
-    if sum(abs.((affect!.gk_step_cache .- affect!.gk_err_cache) .* (bound_r-bound_l) ./
-                2))<tol
+    if sum(abs.((affect!.gk_step_cache .- affect!.gk_err_cache) .* (bound_r-bound_l) ./ 2))<tol
         recursive_axpy!(1, affect!.gk_step_cache .* (bound_r-bound_l) ./ 2, affect!.accumulation_cache)
     else
         integrate_gk!(

--- a/src/integrating_sum.jl
+++ b/src/integrating_sum.jl
@@ -38,8 +38,7 @@ function (affect!::SavingIntegrandSumAffect)(integrator)
     end
     accumulation_cache = recursive_zero!(affect!.accumulation_cache)
     for i in 1:n
-        t_temp = ((integrator.t - integrator.tprev) / 2) * gauss_points[n][i] +
-                 (integrator.t + integrator.tprev) / 2
+        t_temp = ((integrator.t - integrator.tprev) / 2) * gauss_points[n][i] + (integrator.t + integrator.tprev) / 2
         if DiffEqBase.isinplace(integrator.sol.prob)
             curu = first(get_tmp_cache(integrator))
             integrator(curu, t_temp)

--- a/src/probints.jl
+++ b/src/probints.jl
@@ -3,8 +3,7 @@ struct ProbIntsCache{T}
     order::Int
 end
 function (p::ProbIntsCache)(integrator)
-    integrator.u .= integrator.u .+
-                    p.σ * sqrt(integrator.dt^(2 * p.order)) * randn(size(integrator.u))
+    integrator.u .= integrator.u .+ p.σ * sqrt(integrator.dt^(2 * p.order)) * randn(size(integrator.u))
 end
 
 """
@@ -41,9 +40,7 @@ struct AdaptiveProbIntsCache
     order::Int
 end
 function (p::AdaptiveProbIntsCache)(integrator)
-    integrator.u .= integrator.u .+
-                    integrator.EEst * sqrt(integrator.dt^(2 * p.order)) *
-                    randn(size(integrator.u))
+    integrator.u .= integrator.u .+ integrator.EEst * sqrt(integrator.dt^(2 * p.order)) * randn(size(integrator.u))
 end
 
 """

--- a/src/stepsizelimiters.jl
+++ b/src/stepsizelimiters.jl
@@ -6,8 +6,7 @@ mutable struct StepsizeLimiterAffect{F, T, T2, T3}
 end
 # Now make `affect!` for this:
 function (p::StepsizeLimiterAffect)(integrator)
-    integrator.opts.dtmax = p.safety_factor *
-                            p.dtFE(integrator.u, integrator.p, integrator.t)
+    integrator.opts.dtmax = p.safety_factor * p.dtFE(integrator.u, integrator.p, integrator.t)
     if !integrator.opts.adaptive
         if integrator.opts.dtmax < integrator.dtcache
             integrator.dtcache = integrator.opts.dtmax


### PR DESCRIPTION
Initialize fixing unnecessary line splits following Catalyst.jl PR #1306 guidelines. Part of systematic effort across 10+ SciML repositories. 🤖 Generated with Claude Code