### PR TITLE
Exploit that `tstops` are sorted

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -26,7 +26,7 @@ function (f::PresetTimeFunction)(c, u, t, integrator)
     for tstop in _tstops
         add_tstop!(integrator, tstop)
     end
-    if t ∈ tstops
+    if insorted(t, tstops)
         f.user_affect!(integrator)
     end
 end


### PR DESCRIPTION
## Summary
- Use `insorted` instead of `∈` for checking if `t` is in `tstops`
- This is more efficient since `tstops` is a sorted array
- This is a rebase of #266 by @devmotion

## Test plan
- Existing tests should pass as this is a performance optimization that doesn't change behavior
- The `insorted` function performs a binary search on sorted arrays which is O(log n) vs O(n) for `∈`

🤖 Generated with [Claude Code](https://claude.ai/code)