### PR TITLE
Fix undefined fmap reference in integrating_sensitivity_tests.jl

### DIFF
--- a/test/nopre/integrating_sensitivity_tests.jl
+++ b/test/nopre/integrating_sensitivity_tests.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqTsit5, SciMLSensitivity, DiffEqCallbacks,
-      Zygote
+      Zygote, Functors
 using ForwardDiff
 using QuadGK
 using Test
@@ -93,7 +93,7 @@ sol_adjoint_inplace = solve(prob_adjoint_inplace, Tsit5(), abstol = 1e-14, relto
 function callback_saving_inplace_nt(du, u, t, integrator, sol)
     temp = sol(t)
     res = vjp((x) -> lotka_volterra(temp, x, t), integrator.p, u)[1]
-    DiffEqCallbacks.fmap((y, x) -> copyto!(y, x), du, res)
+    fmap((y, x) -> copyto!(y, x), du, res)
     DiffEqCallbacks.recursive_neg!(du)
     return du
 end


### PR DESCRIPTION
## Summary

- Fix `UndefVarError: fmap not defined` error in `test/nopre/integrating_sensitivity_tests.jl`
- The test was calling `DiffEqCallbacks.fmap` but `fmap` is not exported from DiffEqCallbacks - it's only available in the Functors extension module
- Added `Functors` to the imports and use `fmap` directly, matching the pattern already used in `integrating_sum_sensitivity_tests.jl`

## Background

This was discovered during OrdinaryDiffEq.jl downstream CI tests which failed with:
```
LoadError: UndefVarError: `fmap` not defined
```
at `downstream/src/integrating.jl:184` when running the integrating sensitivity tests with NamedTuple parameters.

## Test plan

- [ ] CI passes on this PR
- [ ] OrdinaryDiffEq.jl downstream tests should pass once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)