### PR TITLE
Fix missing DiffEqBase import in saving_tracker_tests.jl

### DIFF
--- a/test/nopre/saving_tracker_tests.jl
+++ b/test/nopre/saving_tracker_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEqTsit5, DiffEqCallbacks
+using OrdinaryDiffEqTsit5, DiffEqCallbacks, DiffEqBase
 using SciMLSensitivity, Tracker
 using Test
 


### PR DESCRIPTION
## Summary

- Fix `UndefVarError: SensitivityADPassThrough not defined` error in `test/nopre/saving_tracker_tests.jl`
- The test uses `SensitivityADPassThrough` which is defined in `DiffEqBase` but was not imported
- Added `DiffEqBase` to the imports

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)