### PR TITLE
Add PrecompileTools workload to improve TTFX

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqCallbacks"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "4.11.0"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
@@ -10,6 +10,7 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -42,6 +43,7 @@ OrdinaryDiffEqRosenbrock = "1.8.0"
 OrdinaryDiffEqTsit5 = "1.1.0"
 OrdinaryDiffEqVerner = "1.1.1"
 Pkg = "1.10.0"
+PrecompileTools = "1.2"
 QuadGK = "2.9"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "3.27"

--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -6,6 +6,7 @@ using DiffEqBase: DiffEqBase, get_tstops, get_tstops_array, get_tstops_max
 using DifferentiationInterface: DifferentiationInterface, Constant
 using LinearAlgebra: LinearAlgebra, adjoint, axpy!, copyto!, mul!, ldiv!
 using Markdown: @doc_str
+using PrecompileTools: PrecompileTools
 using RecipesBase: @recipe
 using RecursiveArrayTools: RecursiveArrayTools, DiffEqArray, copyat_or_push!
 using SciMLBase: SciMLBase, CallbackSet, DiscreteCallback, NonlinearFunction,
@@ -34,5 +35,6 @@ include("preset_time.jl")
 include("probints.jl")
 include("integrating_GK_affect.jl")
 include("integrating_GK_sum.jl")
+include("precompilation.jl")
 
 end # module

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,36 @@
+using PrecompileTools: @compile_workload, @setup_workload
+
+@setup_workload begin
+    @compile_workload begin
+        # Precompile commonly used callback constructors with typical argument types
+
+        # PeriodicCallback - very commonly used for periodic saves/actions
+        periodic_cb = PeriodicCallback(u -> nothing, 1.0)
+        periodic_cb_phase = PeriodicCallback(u -> nothing, 0.5; phase = 0.1)
+
+        # SavingCallback - commonly used for custom saving
+        saved_values_float = SavedValues(Float64, Float64)
+        saving_cb_float = SavingCallback((u, t, integrator) -> t, saved_values_float)
+
+        saved_values_vec = SavedValues(Float64, Vector{Float64})
+        saving_cb_vec = SavingCallback((u, t, integrator) -> copy(u),
+            saved_values_vec)
+
+        # PresetTimeCallback - commonly used for events at specific times
+        preset_cb = PresetTimeCallback([1.0, 2.0, 3.0], integrator -> nothing)
+        preset_cb_single = PresetTimeCallback(1.0, integrator -> nothing)
+
+        # TerminateSteadyState - commonly used for steady-state detection
+        terminate_cb = TerminateSteadyState()
+        terminate_cb_tols = TerminateSteadyState(1e-8, 1e-6)
+
+        # AutoAbstol - commonly used for adaptive tolerance
+        autoabstol_cb = AutoAbstol()
+        autoabstol_cb_init = AutoAbstol(true; init_curmax = 1e-6)
+
+        # IterativeCallback - used for custom iteration patterns
+        iterative_cb = IterativeCallback(
+            integrator -> integrator.t + 1.0,
+            integrator -> nothing)
+    end
+end


### PR DESCRIPTION
## Summary

- Add PrecompileTools.jl as a dependency
- Add precompilation workload for commonly used callback constructors
- Significantly reduces time-to-first-X (TTFX) for common operations

## Performance Improvements

**Before:**
- Package load time: ~1.01 seconds
- Total TTFX (all callbacks): ~1487 ms
  - PeriodicCallback: ~81ms
  - SavingCallback: ~157ms
  - PresetTimeCallback: ~1160ms
  - TerminateSteadyState: ~44ms
  - AutoAbstol: ~45ms

**After:**
- Package load time: ~1.08 seconds (slight increase due to precompilation)
- Total TTFX (all callbacks): ~138 ms
  - PeriodicCallback: ~47ms
  - SavingCallback: ~37ms
  - PresetTimeCallback: ~35ms
  - TerminateSteadyState: ~0ms
  - AutoAbstol: ~0ms
  - IterativeCallback: ~19ms

**TTFX improvement: ~90%**

## Callbacks Precompiled

The following commonly-used callbacks are now precompiled:
- `PeriodicCallback` - very commonly used for periodic saves/actions
- `SavingCallback` + `SavedValues` - commonly used for custom saving
- `PresetTimeCallback` - commonly used for events at specific times
- `TerminateSteadyState` - commonly used for steady-state detection
- `AutoAbstol` - commonly used for adaptive tolerance
- `IterativeCallback` - used for custom iteration patterns

## Invalidation Analysis

Checked for invalidations using SnoopCompile. Found 74 invalidation trees, but they all come from upstream dependencies (Static.jl, RecursiveArrayTools, DataStructures, etc.), not from DiffEqCallbacks.jl itself.

## Test plan

- [x] All 321 existing tests pass
- [x] Verified TTFX improvements with benchmarks

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)