### PR TITLE
Expand JET tests and fix issquare naming conflict

### DIFF
--- a/src/manifold.jl
+++ b/src/manifold.jl
@@ -453,10 +453,10 @@ function compute_manifold_jacobian!(
     return J
 end
 
-issquare(A::AbstractMatrix) = size(A, 1) == size(A, 2)
+_issquare_matrix(A::AbstractMatrix) = size(A, 1) == size(A, 2)
 
 function safe_factorize!(A::AbstractMatrix)
-    if issquare(A)
+    if _issquare_matrix(A)
         fact = LinearAlgebra.cholesky(A; check = false)
         fact_successful(fact) && return fact
     elseif size(A, 1) > size(A, 2)

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -19,9 +19,64 @@ using JET
     if VERSION >= v"1.11"
         # Basic package analysis - only check for critical issues in DiffEqCallbacks itself
         # Note: Many JET warnings come from dependencies, so we use target_modules filter
-        @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.SavedValues(Float64, Float64)
-        @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.IntegrandValues(Float64, Float64)
-        @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.IntegrandValuesSum(Float64)
+
+        @testset "Data structure constructors" begin
+            @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.SavedValues(
+                Float64, Float64)
+            @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.IntegrandValues(
+                Float64, Float64)
+            @test_opt target_modules = (DiffEqCallbacks,) DiffEqCallbacks.IntegrandValuesSum(
+                Float64)
+        end
+
+        @testset "Callback constructors" begin
+            # Test TerminateSteadyState constructor
+            @test_opt target_modules = (DiffEqCallbacks,) TerminateSteadyState()
+            @test_opt target_modules = (DiffEqCallbacks,) TerminateSteadyState(
+                1e-8, 1e-6; min_t = 1.0)
+
+            # Test SavingCallback constructor
+            saved_values = SavedValues(Float64, Float64)
+            save_func = (u, t, integrator) -> sum(u)
+            @test_opt target_modules = (DiffEqCallbacks,) SavingCallback(
+                save_func, saved_values)
+
+            # Test PeriodicCallback constructor
+            periodic_affect = (integrator) -> nothing
+            @test_opt target_modules = (DiffEqCallbacks,) PeriodicCallback(
+                periodic_affect, 0.1)
+
+            # Test PresetTimeCallback constructor
+            preset_affect = (integrator) -> nothing
+            @test_opt target_modules = (DiffEqCallbacks,) PresetTimeCallback(
+                [0.5, 1.0], preset_affect)
+
+            # Test IterativeCallback constructor
+            time_choice = (integrator) -> integrator.t + 0.1
+            iter_affect = (integrator) -> nothing
+            @test_opt target_modules = (DiffEqCallbacks,) IterativeCallback(
+                time_choice, iter_affect)
+
+            # Test AutoAbstol constructor
+            @test_opt target_modules = (DiffEqCallbacks,) AutoAbstol()
+
+            # Test StepsizeLimiter constructor
+            dtFE = (u, p, t) -> 0.01
+            @test_opt target_modules = (DiffEqCallbacks,) StepsizeLimiter(dtFE)
+
+            # Test FunctionCallingCallback constructor
+            func = (u, t, integrator) -> nothing
+            @test_opt target_modules = (DiffEqCallbacks,) FunctionCallingCallback(func)
+
+            # Test PositiveDomain constructor
+            @test_opt target_modules = (DiffEqCallbacks,) PositiveDomain()
+
+            # Test IntegratingCallback constructor
+            integrand_values = IntegrandValues(Float64, Float64)
+            integrand_func = (u, t, integrator) -> sum(u)
+            @test_opt target_modules = (DiffEqCallbacks,) IntegratingCallback(
+                integrand_func, integrand_values, 0.0)
+        end
     else
         @test_broken false  # JET tests skipped on LTS
     end


### PR DESCRIPTION
## Summary

- Expanded JET.jl test coverage to verify type stability of all major callback constructors
- Fixed naming conflict between local `issquare` function and `SciMLBase.issquare`

## Changes

### Expanded JET Tests (`test/qa.jl`)
Added JET `@test_opt` tests for all major callback constructors:
- TerminateSteadyState
- SavingCallback
- PeriodicCallback
- PresetTimeCallback
- IterativeCallback
- AutoAbstol
- StepsizeLimiter
- FunctionCallingCallback
- PositiveDomain
- IntegratingCallback

### Fixed Naming Conflict (`src/manifold.jl`)
Renamed local `issquare(A::AbstractMatrix)` to `_issquare_matrix(A::AbstractMatrix)` to avoid conflict with `SciMLBase.issquare` (re-exported from SciMLOperators). This eliminates the warning:
```
WARNING: using SciMLBase.issquare in module DiffEqCallbacks conflicts with an existing identifier.
```

## Test Plan
- [x] All existing tests pass
- [x] QA/JET tests pass (including newly added tests)
- [x] The issquare warning is eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @ChrisRackauckas