### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqCallbacks"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.13.0"
+version = "4.14.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -47,7 +47,7 @@ PrecompileTools = "1.2"
 QuadGK = "2.9"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "3.27, 4"
-SciMLBase = "2.54"
+SciMLBase = "2.54, 3"
 StaticArrays = "1.9.7"
 StaticArraysCore = "1.4"
 Sundials = "4.19.2"


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 4.13.0 → 4.14.0
- No code changes needed - u_modified! is still available (deprecated) in v3
- Supersedes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)