### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqCallbacks"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.15.0"
+version = "4.16.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -28,7 +28,7 @@ Aqua = "0.8"
 ConcreteStructs = "0.2.3"
 DataInterpolations = "5, 6"
 DataStructures = "0.18.13, 0.19.0"
-DiffEqBase = "6.155.4"
+DiffEqBase = "6.155.4, 7"
 DifferentiationInterface = "0.6.1, 0.7"
 ForwardDiff = "0.10.36"
 Functors = "0.5"


### PR DESCRIPTION
## Summary

Allow `DiffEqBase = "6.155.4, 7"` so that DiffEqCallbacks can be installed alongside the in-development DiffEqBase 7.0.0 (which ships as part of the OrdinaryDiffEq.jl v7 release, currently developed at `lib/DiffEqBase` in the OrdinaryDiffEq monorepo). Bumps the version 4.15.0 → 4.16.0.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch), every `test (Interface{I..V}, …)`, `test (Integrators_{I,II}, …)`, `test (AlgConvergence_{I..III}, …)`, `test (Regression_{I,II}, …)`, `test (Downstream, …)`, `test (ModelingToolkit, …)`, `test (AD, …)`, and the whole sublibrary test matrix fails during package resolution with:

```
ERROR: LoadError: Unsatisfiable requirements detected for package DiffEqCallbacks [459566f4]:
 DiffEqCallbacks [459566f4] log:
 ├─possible versions are: 2.0.0 - 4.15.0 or uninstalled
 ├─restricted to versions * by project [3109894b], leaving only versions: 2.0.0 - 4.15.0
 └─restricted by compatibility requirements with DiffEqBase [2b5f629d] to versions: uninstalled — no versions left
   └─DiffEqBase [2b5f629d] log:
     ├─possible versions are: 7.0.0 or uninstalled
     ├─restricted to versions 7 by OrdinaryDiffEqTsit5 [b1df2697], …
     └─DiffEqBase [2b5f629d] is fixed to version 7.0.0
```

i.e. DiffEqCallbacks's `DiffEqBase = "6.155.4"` excludes the 7.0.0 that every OrdinaryDiffEq v7 sublibrary now requires. The downstream-test job for this package (`DiffEqCallbacks.jl/All/1.10`) passes on the same PR because that workflow `Pkg.develop`s every `lib/` entry and `develop` bypasses compat — so the source is already known to work with DiffEqBase 7.

## Why this is source-level safe

DiffEqCallbacks does not use any of the symbols that v7 removed from DiffEqBase / SciMLBase:

- No `u_modified!` call sites (the one reference in `src/DiffEqCallbacks.jl` is the `@static if isdefined(SciMLBase, :derivative_discontinuity!)` shim that falls back to `u_modified!` only on SciMLBase v2). All actual callsites use `derivative_discontinuity!`.
- No `sol.destats` / `has_destats` / `DEStats` / `DEAlgorithm` / `DEProblem` / `DESolution` / `concrete_solve` / `fastpow` / `RECOMPILE_BY_DEFAULT` / `QuadratureProblem` / `tuples()` / `intervals()`.
- No integer-indexing of solutions (`sol[i]`) — nothing in the RAT v4 breaking-change table applies.

The only DiffEqBase imports are `get_tstops`, `get_tstops_array`, `get_tstops_max` (all still present in v7).

## Verified locally

With `lib/DiffEqBase` v7.0.0 from SciML/OrdinaryDiffEq.jl `dev`-ed into DiffEqCallbacks, on Julia 1.11:

- Module loads clean (`DiffEqCallbacks.pkgversion(DiffEqCallbacks) == v"4.16.0"`, `DiffEqBase.pkgversion(DiffEqBase) == v"7.0.0"`).
- `SavingCallback` on `Tsit5`: produces expected saved values.
- `PresetTimeCallback`: affect fires at both requested tstops.
- `PeriodicCallback`: affect fires on every period.
- `TerminateSteadyState`: stops the integration when the residual falls below threshold.
- `AutoAbstol`: runs through to `tspan[2]` with auto-adjusted `abstol`.
- `StepsizeLimiter`: caps `dt` at the limiter's return value.

## Test plan

- [x] `Pkg.develop` DiffEqCallbacks and `lib/DiffEqBase` v7.0.0; verified resolve + load + the six callback types above.
- [ ] CI on this PR (against the currently-registered DiffEqBase 6.x line — expected green; source unchanged).
- [ ] OrdinaryDiffEq.jl#3488 CI once this is registered and the General-registry compat opens up — the `Unsatisfiable requirements detected for package DiffEqCallbacks` line should disappear from every affected job.

## Related downstream packages that also need the same compat bump

For reference, the resolver failure on #3488 also names `DiffEqNoiseProcess`, `StochasticDiffEq`, `Sundials`, `ODEInterfaceDiffEq`, `ModelingToolkit`, `Catalyst`, `JumpProcesses`, `DelayDiffEq`, `ParameterizedFunctions`, and a handful of smaller downstream packages, all currently capped at `DiffEqBase = "6.x"`. Those are out of scope here but will each need the equivalent bump before OrdinaryDiffEq v7 can actually release with a clean downstream matrix.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>