### PR TITLE
Make PresetTimeCallback robust to tstop roundoff

### DIFF
--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -6,9 +6,9 @@ struct PresetTimeFunction{T, T2, T3}
 end
 function (f::PresetTimeFunction)(u, t, integrator)
     return if hasproperty(integrator, :dt)
-        insorted(t, f.tstops) && (integrator.t - integrator.dt) != integrator.t
+        is_preset_time(t, f.tstops) && (integrator.t - integrator.dt) != integrator.t
     else
-        insorted(t, f.tstops)
+        is_preset_time(t, f.tstops)
     end
 end
 
@@ -26,9 +26,26 @@ function (f::PresetTimeFunction)(c, u, t, integrator)
     for tstop in _tstops
         add_tstop!(integrator, tstop)
     end
-    return if insorted(t, tstops)
+    return if is_preset_time(t, tstops)
         f.user_affect!(integrator)
     end
+end
+
+function is_preset_time(t, tstops)
+    insorted(t, tstops) && return true
+    i = searchsortedfirst(tstops, t)
+    return (i <= length(tstops) && is_close_preset_time(t, tstops[i])) ||
+        (i > firstindex(tstops) && is_close_preset_time(t, tstops[i - 1]))
+end
+
+function is_close_preset_time(t, tstop)
+    _t, _tstop = promote(t, tstop)
+    if _t isa AbstractFloat && _tstop isa AbstractFloat && isfinite(_t) && isfinite(_tstop)
+        scale = max(abs(_t), abs(_tstop))
+        return abs(_t - _tstop) <= 100 * eps(scale)
+    end
+
+    return t == tstop
 end
 
 """

--- a/test/preset_time.jl
+++ b/test/preset_time.jl
@@ -34,6 +34,18 @@ sol = integrator.sol
 @test 0.6 ∈ sol.t
 @test p != startp
 
+struct PresetTimeRoundoffIntegrator{T}
+    t::T
+    dt::T
+end
+
+roundoff_integrator = PresetTimeRoundoffIntegrator(8.999999999999996, 0.1)
+for tstops in ([2, 9], range(2, 9; length = 2), [2.0, 9.0])
+    roundoff_cb = PresetTimeCallback(tstops, integrator -> nothing)
+    @test roundoff_cb.condition(nothing, 8.999999999999996, roundoff_integrator)
+    @test !roundoff_cb.condition(nothing, 9.0 - 1.0e-10, roundoff_integrator)
+end
+
 notcalled = true
 prob = ODEProblem(some_dynamics, u0, tspan, p)
 cb = PresetTimeCallback([1.2], integrator -> notcalled = false)


### PR DESCRIPTION
## Summary

- Fixes `PresetTimeCallback` matching when an integrator reaches a preset floating-point time within roundoff instead of at the exact stored `tstop`.
- Keeps the exact `insorted` path, then checks the nearest sorted preset time with a small floating-point tolerance after promoting the solver time and preset time together.
- Adds focused regressions for a `9.0` preset time reached as `8.999999999999996`, covering integer vector, Julia range, and floating vector schedules; this is the callback-side behavior behind SciML/DifferentialEquations.jl#1124.

## Explanation

`PresetTimeCallback` currently checks preset times with exact sorted membership. That can skip the callback when upstream time stepping lands on the intended stop with a representational roundoff, which showed up in the downstream DDE reproducer from SciML/DifferentialEquations.jl#1124.

This makes the callback predicate robust to that case by preserving the exact membership check first, then comparing only the nearest candidate `tstop`s from the sorted preset-time vector. The comparison promotes `t` and the candidate `tstop` together, so schedules like `[2, 9]` and `2:7:9` are handled the same way as `[2.0, 9.0]` when the solver time is floating-point. Non-floating comparisons and exact matches keep the existing behavior.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'`
  - Passed: `DiffEqCallbacks | 373 pass / 373 total`.
- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path="/private/tmp/DiffEqCallbacks-1124"); Pkg.add("OrdinaryDiffEqTsit5"); include("/private/tmp/DiffEqCallbacks-1124/test/preset_time.jl")'`
  - Passed with no test failures.
- Downstream DDE reproducer based on SciML/DifferentialEquations.jl#1124 with local `DiffEqCallbacks` and explicit `MethodOfSteps(Tsit5())`.
  - Passed: fired preset events included `(:up, 9.0)` and `sol.retcode = SciMLBase.ReturnCode.Success`.
- `julia --project=@runic -e 'using Runic; exit(Runic.main(["--check", "src/preset_time.jl", "test/preset_time.jl"]))'`
  - Passed.
- `git diff --check`
  - Passed.
