### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,25 +13,11 @@ on:
 jobs:
   test:
     if: false  # Temporarily disabled, see issue #292
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group:
-          - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "Core"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/test/integrating_GK_sum_tests.jl
+++ b/test/integrating_GK_sum_tests.jl
@@ -13,7 +13,7 @@ sol = solve(
 )
 @test integrated.integrand[1] == 1
 
-# test to enter reccursion
+# test to enter recursion
 integrated = IntegrandValuesSum(zeros(1))
 sol = solve(
     prob, Euler(),

--- a/test/integrating_GK_tests.jl
+++ b/test/integrating_GK_tests.jl
@@ -13,7 +13,7 @@ sol = solve(
 )
 @test all(integrated.integrand .≈ [[0.1] for i in 1:10])
 
-# test to enter reccursion
+# test to enter recursion
 integrated = IntegrandValues(Float64, Vector{Float64})
 sol = solve(
     prob, Euler(),


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the centralized SciML reusable workflows (all pinned `@v1`, every caller passes `secrets: "inherit"`). End state matches the Sundials.jl pattern: every check is a central caller.

## Converted (inline -> central)
- **FormatCheck.yml**: `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving the existing `if: false` disable (issue #292) and the prior settings: `julia-version: "1.10"`, `group: "Core"`, `skip: "Pkg,TOML"`, `allow-reresolve: false`. (The legacy `downgrade_mode: alldeps` matrix axis has no equivalent input in the central caller; the standard downgrade behavior is used.)

## Already central (unchanged)
- **Tests.yml** — already a `tests.yml@v1` caller (matrix `version=[1,lts,pre] x group=[Core,QA,NoPre] x os=[ubuntu,macos,windows]`) with `secrets: "inherit"`.
- **Documentation.yml** — already a `documentation.yml@v1` caller with `secrets: "inherit"`.
- **TagBot.yml** — left unchanged.

## Other changes
- **dependabot.yml**: removed the now-unneeded `crate-ci/typos` version-ignore block. The `github-actions` (weekly, `/`) and `julia` (daily, group all-julia-packages over `/`, `/docs`, `/test`) blocks are preserved.
- **Typos fixed**: 2 (`reccursion` -> `recursion` in `test/integrating_GK_tests.jl` and `test/integrating_GK_sum_tests.jl`).
- **Runic**: ran `Runic.main(["--inplace","."])` locally — no formatting changes (the repo was already Runic-clean from the prior inline check).

## Heads-up
The check job names change (now rendered through the reusable workflows), so any **branch-protection required status checks** referencing the old job names will need to be updated to the new names.

No CompatHelper, Downstream, or Benchmark workflows existed, so none were added/converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)