### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,10 @@
+name: "Doc Preview Cleanup"
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+jobs:
+  cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the standard SciML centralized caller workflows that were missing from this repo, pointing at the shared reusable workflows in `SciML/.github`.

Added:
- **RunicSuggestions.yml** — Runic auto-format suggestions on PRs (`runic-suggestions-on-pr.yml@v1`). This repo already uses Runic for its format check, so the suggestions caller is the matching companion.
- **DependabotAutoMerge.yml** — auto-merge Dependabot PRs (`dependabot-automerge.yml@v1`).
- **DocPreviewCleanup.yml** — clean up gh-pages doc previews when a PR is closed (`docs-preview-cleanup.yml@v1`). This repo has a `docs/` Documenter site.

Only the new `.github/workflows/*.yml` caller files are added; no existing files, code, or `Project.toml` were touched.

---
**Please ignore this PR until reviewed by @ChrisRackauckas.** It is opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)