### PR TITLE
ci: drop removed allow-reresolve input from Downgrade caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,5 +19,4 @@ jobs:
       julia-version: "1.10"
       group: "Core"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## What

Removes the now-invalid `allow-reresolve: false` line from the `with:` block of the centralized Downgrade caller in `.github/workflows/Downgrade.yml`.

## Why

The central reusable workflow `SciML/.github/.github/workflows/downgrade.yml@v1` was retagged and **no longer declares an `allow-reresolve` input**. GitHub Actions errors when a caller passes a `with:` key that the called reusable workflow does not declare, so on the default branch the Downgrade job now fails with an invalid-input error.

This caller is the last remaining one in the repo still passing the removed input. Dropping the single line realigns it with the current v1 interface.

Verified against the live central workflow:
- `gh api repos/SciML/.github/contents/.github/workflows/downgrade.yml?ref=v1` -> no `allow-reresolve` input declared.

## Scope

`git show --stat`:
```
 .github/workflows/Downgrade.yml | 1 -
 1 file changed, 1 deletion(-)
```

Only the single `allow-reresolve: false` line is removed; no other behavior changes. (Note: the `test` job remains `if: false`/disabled per issue #292 — that is unchanged here.)

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)