### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,25 +18,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - "Core"
-          - "QA"
-          - "NoPre"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,11 @@
+[Core]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+[QA]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+[NoPre]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
## Summary

Converts the root `Tests.yml` test workflow into the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the test matrix declared once in a root `test/test_groups.toml`.

The `jobs.tests` block is now simply:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

No `with:` inputs are needed: the old caller used all defaults (`GROUP` env var, `check-bounds: yes`, coverage on, `coverage-directories: src,ext`, no apt packages). `runtests.jl` already dispatches on `GROUP` (Core / QA / NoPre), so it is unchanged.

The `on:` triggers and `concurrency:` block are preserved verbatim, and the filename (`Tests.yml`) and `name: "Tests"` are unchanged so existing branch-protection status checks keep matching.

## Matrix declared in `test/test_groups.toml`

```toml
[Core]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]

[QA]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]

[NoPre]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]
```

## Matrix match: 27/27 exact

Verified with `scripts/compute_affected_sublibraries.jl . --root-matrix` (SciML/.github@v1). The emitted `(group, version, runner)` set is exactly the old `Tests.yml` cartesian product — `{Core, QA, NoPre} x {1, lts, pre} x {ubuntu-latest, macos-latest, windows-latest}` = 27 cells, no missing, no extra. TOML and YAML both parse cleanly.

## QA findings

None. Category A repo — `runtests.jl` already has `Core`/`QA`/`NoPre` GROUP dispatch and a `QA` group running Aqua; no runtests.jl change and no source-bug exclusions were introduced. `Project.toml` metadata already conforms (julia floor `1.10` LTS, `[compat]` entries present, `[extras]`/`[targets].test` aligned), so no benign-metadata fixes were required.

Ignore until reviewed by @ChrisRackauckas.