### PR TITLE
Import ReturnCode in independentlylinearizedtests.jl (fixes Core test group)

### DIFF
--- a/src/probints.jl
+++ b/src/probints.jl
@@ -1,3 +1,16 @@
+# Read the integrator's scalar error estimate. Older integrators stored it as the
+# `EEst` field directly; current OrdinaryDiffEqCore moved it onto the controller
+# cache (`integrator.controller_cache.EEst`, exposed there as `get_EEst`). Reading
+# it this way keeps DiffEqCallbacks free of an OrdinaryDiffEqCore dependency while
+# supporting both integrator layouts.
+function _integrator_EEst(integrator)
+    if hasproperty(integrator, :EEst)
+        return getproperty(integrator, :EEst)
+    else
+        return integrator.controller_cache.EEst
+    end
+end
+
 struct ProbIntsCache{T}
     σ::T
     order::Int
@@ -40,7 +53,7 @@ struct AdaptiveProbIntsCache
     order::Int
 end
 function (p::AdaptiveProbIntsCache)(integrator)
-    return integrator.u .= integrator.u .+ integrator.EEst * sqrt(integrator.dt^(2 * p.order)) * randn(size(integrator.u))
+    return integrator.u .= integrator.u .+ _integrator_EEst(integrator) * sqrt(integrator.dt^(2 * p.order)) * randn(size(integrator.u))
 end
 
 """

--- a/test/AD/saving_tracker_tests.jl
+++ b/test/AD/saving_tracker_tests.jl
@@ -30,7 +30,11 @@ u0 = TrackedArray([1.0f0, 0.0f0, 0.0f0])
 tspan = TrackedArray([0.0f0, 1.0f0])
 prob = ODEProblem{false}(rober, u0, tspan, p)
 saved_values = SavedValues(eltype(tspan), eltype(p))
-cb = SavingCallback((u, t, integrator) -> integrator.EEst * integrator.dt, saved_values)
+# OrdinaryDiffEqCore's ODEIntegrator no longer has an `EEst` field; the scalar
+# error estimate now lives on the controller cache.
+eest(integrator) = hasproperty(integrator, :EEst) ? integrator.EEst :
+    integrator.controller_cache.EEst
+cb = SavingCallback((u, t, integrator) -> eest(integrator) * integrator.dt, saved_values)
 
 @test !all(
     iszero.(

--- a/test/independentlylinearizedtests.jl
+++ b/test/independentlylinearizedtests.jl
@@ -1,5 +1,6 @@
 using Test, DiffEqCallbacks
 using DiffEqCallbacks: sample, store!, IndependentlyLinearizedSolutionChunks, finish!
+using SciMLBase: ReturnCode
 
 @testset "IndependentlyLinearizedSolution" begin
     ils = IndependentlyLinearizedSolution{Float64, Float64}(

--- a/test/integrating_GK_sum_tests.jl
+++ b/test/integrating_GK_sum_tests.jl
@@ -26,10 +26,136 @@ sol = solve(
 
 #### TESTING ON LINEAR SYSTEM WITH ANALYTICAL SOLUTION ####
 
-# Reuse shared helper functions defined in integrating_GK_tests.jl:
-# compute_dGdp, compute_dGdp_nt, simple_linear_system, adjoint_linear,
-# adjoint_linear_inplace, analytical_derivative, callback_saving_linear,
-# callback_saving_linear_inplace
+function compute_dGdp(integrand)
+    temp = zeros(length(integrand.integrand), length(integrand.integrand[1]))
+    for i in 1:length(integrand.integrand)
+        for j in 1:length(integrand.integrand[1])
+            temp[i, j] = integrand.integrand[i][j]
+        end
+    end
+    return sum(temp, dims = 1)[:]
+end
+
+function simple_linear_system(u, p, t)
+    a, b = p
+    return [-a * u[2], b * u[1]]
+end
+
+function adjoint_linear(u, p, t, sol)
+    a, b = p
+    return -[0 b; -a 0] * u - 2.0 * (sol(t) .- 1.0)
+end
+
+function adjoint_linear_inplace(du, u, p, t, sol)
+    a, b = p
+    return du .= -[0 b; -a 0] * u - 2.0 * (sol(t) .- 1.0)
+end
+
+function analytical_derivative(p, t)
+    a, b = p
+    d1 = (
+        b * (
+            (cos(2t * sqrt(a * b)) - 4cos(t * sqrt(a * b))) / (b * sqrt(a / b)) +
+                (b * t * cos(2t * sqrt(a * b))) / sqrt(a * b) +
+                (-4b * t * cos(t * sqrt(a * b))) / sqrt(a * b) +
+                2(
+                (2b * t * sin(t * sqrt(a * b))) / sqrt(a * b) +
+                    (-b * t * sin(2t * sqrt(a * b))) / sqrt(a * b)
+            ) * sqrt(a / b)
+        ) +
+            (b * t * (a + 3b)) / sqrt(a * b) +
+            (-a * b * t * cos(2t * sqrt(a * b))) / sqrt(a * b) + 3 / sqrt(a / b) +
+            2t * sqrt(a * b) - sin(2t * sqrt(a * b))
+    ) / (4.0(a^0.5) * (b^1.5)) +
+        (
+        (3a * (b / (a^2))) / sqrt(b / a) +
+            (a * (b / (a^2)) * cos(2t * sqrt(a * b))) / sqrt(b / a) +
+            (b * t * (b + 3a)) / sqrt(a * b) +
+            (b * t * (a - b) * cos(2t * sqrt(a * b))) / sqrt(a * b) +
+            (-4a * (b / (a^2)) * cos(t * sqrt(a * b))) / sqrt(b / a) +
+            (-4a * b * t * cos(t * sqrt(a * b))) / sqrt(a * b) +
+            (2a * b * t * sqrt(b / a) * sin(2t * sqrt(a * b))) / sqrt(a * b) +
+            (-4a * b * t * sqrt(b / a) * sin(t * sqrt(a * b))) / sqrt(a * b) +
+            6t * sqrt(a * b) + 8sqrt(b / a) * cos(t * sqrt(a * b)) + sin(2t * sqrt(a * b)) -
+            6sqrt(b / a) - 8sin(t * sqrt(a * b)) - 2sqrt(b / a) * cos(2t * sqrt(a * b))
+    ) /
+        (4.0(a^1.5) * (b^0.5)) +
+        (
+        -2.0(b^1.5) *
+            (
+            (
+                b * (
+                    2(cos(2t * sqrt(a * b)) - 4cos(t * sqrt(a * b))) * sqrt(a / b) +
+                        sin(2t * sqrt(a * b)) - 8sin(t * sqrt(a * b))
+                ) + 6b * sqrt(a / b) +
+                    2t * (a + 3b) * sqrt(a * b) - a * sin(2t * sqrt(a * b))
+            ) / (16.0a * (b^3.0))
+        )
+    ) /
+        (a^0.5) -
+        6.0(a^0.5) * (b^0.5) *
+        (
+        (
+            (a - b) * sin(2t * sqrt(a * b)) + 8a * sqrt(b / a) * cos(t * sqrt(a * b)) +
+                2t * (b + 3a) * sqrt(a * b) - 6a * sqrt(b / a) - 8a * sin(t * sqrt(a * b)) -
+                2a * sqrt(b / a) * cos(2t * sqrt(a * b))
+        ) / (16.0b * (a^3.0))
+    )
+    d2 = (
+        b * (
+            (a * t * cos(2t * sqrt(a * b))) / sqrt(a * b) +
+                (-(a / (b^2)) * (cos(2t * sqrt(a * b)) - 4cos(t * sqrt(a * b)))) / sqrt(a / b) +
+                (-4a * t * cos(t * sqrt(a * b))) / sqrt(a * b) +
+                2(
+                (2a * t * sin(t * sqrt(a * b))) / sqrt(a * b) +
+                    (-a * t * sin(2t * sqrt(a * b))) / sqrt(a * b)
+            ) * sqrt(a / b)
+        ) +
+            (-3b * (a / (b^2))) / sqrt(a / b) + (a * t * (a + 3b)) / sqrt(a * b) +
+            (-t * (a^2) * cos(2t * sqrt(a * b))) / sqrt(a * b) + 6sqrt(a / b) +
+            2(cos(2t * sqrt(a * b)) - 4cos(t * sqrt(a * b))) * sqrt(a / b) +
+            6t * sqrt(a * b) + sin(2t * sqrt(a * b)) - 8sin(t * sqrt(a * b))
+    ) /
+        (4.0(a^0.5) * (b^1.5)) +
+        (
+        (4cos(t * sqrt(a * b))) / sqrt(b / a) + (-cos(2t * sqrt(a * b))) / sqrt(b / a) +
+            (a * t * (b + 3a)) / sqrt(a * b) +
+            (-4t * (a^2) * cos(t * sqrt(a * b))) / sqrt(a * b) +
+            (a * t * (a - b) * cos(2t * sqrt(a * b))) / sqrt(a * b) +
+            (-4t * (a^2) * sqrt(b / a) * sin(t * sqrt(a * b))) / sqrt(a * b) +
+            (2t * (a^2) * sqrt(b / a) * sin(2t * sqrt(a * b))) / sqrt(a * b) +
+            -3 / sqrt(b / a) + 2t * sqrt(a * b) - sin(2t * sqrt(a * b))
+    ) /
+        (4.0(a^1.5) * (b^0.5)) +
+        (
+        -2.0(a^1.5) *
+            (
+            (
+                (a - b) * sin(2t * sqrt(a * b)) + 8a * sqrt(b / a) * cos(t * sqrt(a * b)) +
+                    2t * (b + 3a) * sqrt(a * b) - 6a * sqrt(b / a) - 8a * sin(t * sqrt(a * b)) -
+                    2a * sqrt(b / a) * cos(2t * sqrt(a * b))
+            ) / (16.0b * (a^3.0))
+        )
+    ) / (b^0.5) -
+        6.0(a^0.5) * (b^0.5) *
+        (
+        (
+            b * (
+                2(cos(2t * sqrt(a * b)) - 4cos(t * sqrt(a * b))) * sqrt(a / b) +
+                    sin(2t * sqrt(a * b)) - 8sin(t * sqrt(a * b))
+            ) + 6b * sqrt(a / b) +
+                2t * (a + 3b) * sqrt(a * b) - a * sin(2t * sqrt(a * b))
+        ) / (16.0a * (b^3.0))
+    )
+    return [d1, d2]
+end
+
+function callback_saving_linear(u, t, integrator, sol)
+    return -1 .* [-sol(t)[2] 0; 0 sol(t)[1]]' * u
+end
+function callback_saving_linear_inplace(du, u, t, integrator, sol)
+    return du .= -1 .* [-sol(t)[2] 0; 0 sol(t)[1]]' * u
+end
 
 u0 = [1.0, 1.0]     # initial condition
 tspan = (0.0, 10.0) # simulation time


### PR DESCRIPTION
## Problem

The Core test group fails on master across every Julia version / OS:

```
IndependentlyLinearizedSolutionChunks: Test Failed at test/independentlylinearizedtests.jl:112
    Expected: ArgumentError
      Thrown: UndefVarError
      UndefVarError: `ReturnCode` not defined in `Main.var"##Core/independentlylinearizedtests.jl#280"`
```

## Root cause

`test/independentlylinearizedtests.jl` references `ReturnCode.Default` (lines 112, 117, 122, 125) but only does `using Test, DiffEqCallbacks` plus a narrow `using DiffEqCallbacks: sample, store!, ...` — it never imports `ReturnCode`. `DiffEqCallbacks` does not export `ReturnCode`, so it was never actually in scope on its own.

This only surfaced after #316 ("Use SciMLTesting v1.2 folder-based run_tests"). The SciMLTesting v1.2 harness runs each test file in its own isolated module (`Main.var"##Core/independentlylinearizedtests.jl#280"`). Previously, under the old `runtests.jl`, all files were `include`d into one shared module, so `ReturnCode` leaked in from `periodic_tests.jl` (which does `using SciMLBase: ... ReturnCode`). With per-file modules that leakage is gone and the missing import is now a hard error.

## Fix

Add `using SciMLBase: ReturnCode` to the test file, matching the existing pattern in `test/periodic_tests.jl`. SciMLBase is already a direct dependency.

This is the only failure in the Core group; the other Core files (`autoabstol`, `domain`, `funccall`) pass.

## Local verification (Julia 1.10.11, the package's compat floor)

Ran the file inside a fresh isolated module to mimic the SciMLTesting harness:

```
Test Summary:                   | Pass  Total  Time
IndependentlyLinearizedSolution |   15     15
Test Summary:                         | Pass  Total  Time
IndependentlyLinearizedSolutionChunks |   16     16
>>> independentlylinearizedtests.jl COMPLETED WITHOUT ERROR <<<
```

Reverting the one-line import reproduces the exact CI failure (`Thrown: UndefVarError` at lines 112/117/...), confirming causation.

## Scope

This PR fixes only the Core `ReturnCode` failure. The other red checks on master are separate, genuine upstream/dependency breakages and are intentionally left out of this focused PR:
- **AD group** — `test/AD/saving_tracker_tests.jl` accesses `integrator.EEst`, a field OrdinaryDiffEq's `ODEIntegrator` no longer has (`FieldError`). Real upstream API change.
- **Documentation** — `using OrdinaryDiffEq` in `@example` blocks leaves `Euler`/`EnsembleProblem` undefined; OrdinaryDiffEq loading/re-export regression.
- **Downgrade / Core** — `DiffEqBaseChainRulesCoreExt` method-overwriting precompile error + `could not import SciMLBase.NoiseSizeIncompatabilityError into DiffEqBase`; a DiffEqBase/SciMLBase downgrade compat-floor conflict.

Please ignore until reviewed by @ChrisRackauckas.
---

## Update (additional commit: self-contained `integrating_GK_sum_tests.jl`)

After the `ReturnCode` fix, the Core group was still red on a *different* file with the **same root cause**: `test/integrating_GK_sum_tests.jl` relied on helper functions (`simple_linear_system`, `adjoint_linear[_inplace]`, `analytical_derivative`, `callback_saving_linear[_inplace]`, `compute_dGdp`) defined in `integrating_GK_tests.jl`. Under the SciMLTesting v1.2 per-file isolated-module harness those no longer leak across files, so it errored with:

```
Core/integrating_GK_sum_tests.jl: UndefVarError: `simple_linear_system` not defined
  @ test/integrating_GK_sum_tests.jl:37
```

Fix: define those helpers inline (matching the self-contained pattern of the other Core files).

This also fixes the **Downgrade / Core** group — contrary to the earlier note above, its only *fatal* error was the very same `simple_linear_system` `UndefVarError` (the `DiffEqBaseChainRulesCoreExt` method-overwrite and `NoiseSizeIncompatabilityError` lines were non-fatal `WARNING:`s, not the failure).

### Local verification (Julia 1.10.11, the Core compat floor)

Ran the file inside a fresh isolated `Module` to mimic the harness:

```
[ Info: Running .../test/integrating_GK_sum_tests.jl in isolated module ##Core/integrating_GK_sum_tests.jl#repro
>>> integrating_GK_sum_tests.jl COMPLETED WITHOUT ERROR <<<
```

Reverting just this commit reproduces the exact CI error (`UndefVarError: simple_linear_system not defined` at line 37), confirming causation.

### Still out of scope (separate, genuine upstream breakages)
- **AD group** — `test/AD/saving_tracker_tests.jl:33` and `src/probints.jl:43` access `integrator.EEst`, a field OrdinaryDiffEqCore's `ODEIntegrator` no longer has (`FieldError`). Real upstream API change; needs a source-side fix to read the error estimate from its new location.
- **Documentation** — `using OrdinaryDiffEq` leaves `Euler`/`EnsembleProblem` undefined in `@example` blocks; an OrdinaryDiffEq loading/re-export regression.
---

## Update (additional commit: read error estimate without the removed `EEst` field)

Fixes the **AD group** breakage that was previously listed as out of scope, and the same failure in the **Core group**.

### Root cause

OrdinaryDiffEqCore's `ODEIntegrator` no longer has an `EEst` field — the scalar error estimate moved onto the controller cache (`integrator.controller_cache.EEst`, surfaced there as `get_EEst`). Reading `integrator.EEst` directly now throws:

```
FieldError: type OrdinaryDiffEqCore.ODEIntegrator has no field `EEst`
```

This broke two call sites:
- `src/probints.jl:43` in `AdaptiveProbIntsUncertainty`, exercised by the Core group's `test/probints.jl` (`AdaptiveProbIntsUncertainty(5)` + adaptive `Tsit5`).
- `test/AD/saving_tracker_tests.jl:33`, the AD group's `SavingCallback` save function.

### Fix

Add a dependency-free `_integrator_EEst(integrator)` accessor that uses the `EEst` field when present (older integrators / SDE integrators) and otherwise reads it off the controller cache. This keeps DiffEqCallbacks free of an OrdinaryDiffEqCore dependency while supporting both integrator layouts — mirroring how the current DelayDiffEq accesses `OrdinaryDiffEqCore.get_EEst`. The same fallback is applied in the AD test.

### Local verification

Julia 1.12.6 (the "1" channel) and Julia 1.10.11 (compat floor), with OrdinaryDiffEqCore 4.3.0 (the new layout) resolving on both:

```
# AD group
Test Summary:     | Pass  Total   Time
AD/saving_tracker |    1      1  22.8s

# Core group (probints.jl)
>>> probints.jl COMPLETED <<<   (Julia 1.12 and 1.10, exit 0)
```

Reverting the commit reproduces `FieldError: type ODEIntegrator has no field EEst` at `src/probints.jl` and `saving_tracker_tests.jl`, confirming causation. Both branches of `_integrator_EEst` were unit-checked against mock integrators (field-present and controller-cache layouts).

Please ignore until reviewed by @ChrisRackauckas.
