### PR TITLE
Release prep: bump DiffEqCallbacks to 4.18.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqCallbacks"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.18.2"
+version = "4.18.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release bump to register the accumulated docstring/QA/test-scaffolding changes since 4.18.2 (no functional/source changes).