### PR TITLE
Fix PeriodicCallback with Rational Δt (DE #878)

### DIFF
--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -124,8 +124,10 @@ end
 
 function add_next_tstop!(integrator, S::PeriodicCallbackAffect)
     cache = _periodic_cache(S.cache_key, typeof(S.Δt))
-    # Schedule next call to `f` using `add_tstops!`, but be careful not to keep integrating forever
-    tnew = cache.t0[] + (cache.index[] + 1) * S.Δt
+    # Schedule next call to `f` using `add_tstops!`, but be careful not to keep integrating forever.
+    # Convert into the integrator time type so Rational Δt produces Float64
+    # tstops that match the condition comparison (DifferentialEquations.jl #878).
+    tnew = convert(typeof(integrator.t), cache.t0[] + (cache.index[] + 1) * S.Δt)
     #=
     Okay yeah, this is nasty
     the comparer is always less than for type stability, so in order
@@ -203,8 +205,12 @@ function PeriodicCallback(
     condition = function (u, t, integrator)
         cache = _periodic_cache(cache_key, typeof(Δt))
         fin = isfinished(integrator)
-        return (t == (cache.t0[] + cache.index[] * Δt) && !fin) ||
-            (final_affect && fin)
+        # Convert the Rational (or other) period target into the integrator's
+        # time type. Exact `t == t0 + index*Δt` fails when `t::Float64` and
+        # `Δt::Rational` because e.g. `Float64(3//10) == 3//10` is false
+        # (DifferentialEquations.jl #878).
+        t_target = convert(typeof(t), cache.t0[] + cache.index[] * Δt)
+        return (t == t_target && !fin) || (final_affect && fin)
     end
 
     # Call f, update tnext, and make sure we stop at the new tnext

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -110,7 +110,7 @@ sol = solve(prob, Tsit5(), callback = cb)
 @testset "Rational PeriodicCallback period" begin
     firings = Float64[]
     cb_rat = PeriodicCallback(
-        integrator -> push!(firings, integrator.t), 1//10;
+        integrator -> push!(firings, integrator.t), 1 // 10;
         initial_affect = true
     )
     prob_rat = ODEProblem((du, u, p, t) -> (du[1] = -u[1]), [1.0], (0.0, 1.0))
@@ -121,7 +121,7 @@ sol = solve(prob, Tsit5(), callback = cb)
     # interior grid).
     @test length(firings) >= 10
     @test firings[1] == 0.0
-    @test all(isapprox(firings[i], (i - 1) / 10; atol = 1e-12) for i in eachindex(firings) if firings[i] <= 1.0)
+    @test all(isapprox(firings[i], (i - 1) / 10; atol = 1.0e-12) for i in eachindex(firings) if firings[i] <= 1.0)
 end
 
 # Fix indexing repeats

--- a/test/periodic_tests.jl
+++ b/test/periodic_tests.jl
@@ -105,6 +105,25 @@ prob = ODEProblem(fff, u0, tspan, p)
 sol = solve(prob, Tsit5(), callback = cb)
 @test sol.t[end] == tspan[2]
 
+# Rational Δt must fire periodically (DifferentialEquations.jl #878).
+# Exact `t == t0 + index*Δt` fails when t is Float64 and Δt is Rational.
+@testset "Rational PeriodicCallback period" begin
+    firings = Float64[]
+    cb_rat = PeriodicCallback(
+        integrator -> push!(firings, integrator.t), 1//10;
+        initial_affect = true
+    )
+    prob_rat = ODEProblem((du, u, p, t) -> (du[1] = -u[1]), [1.0], (0.0, 1.0))
+    sol_rat = solve(prob_rat, Tsit5(); callback = cb_rat)
+    @test sol_rat.retcode == ReturnCode.Success
+    # t = 0, 0.1, ..., 1.0 → 11 firings (initial + 10 periods; final tstop may or
+    # may not double-fire depending on tstop handling — require at least the
+    # interior grid).
+    @test length(firings) >= 10
+    @test firings[1] == 0.0
+    @test all(isapprox(firings[i], (i - 1) / 10; atol = 1e-12) for i in eachindex(firings) if firings[i] <= 1.0)
+end
+
 # Fix indexing repeats
 # https://github.com/SciML/ModelingToolkit.jl/issues/2528
 


### PR DESCRIPTION
## Summary

- `PeriodicCallback` condition used exact `t == t0 + index*Δt`.
- With `Δt::Rational` and `t::Float64`, equality is always false after t0 (`Float64(3//10) == 3//10` is false), so the callback never re-fires.
- Convert period targets and scheduled tstops into the integrator time type.

Fixes SciML/DifferentialEquations.jl#878

This PR should be ignored until reviewed by @ChrisRackauckas.

## Test plan

- [x] Local: Rational `1//10` fires ~10 times on `[0,1]` (was 1)
- [x] Local: Float64 periods still work
- [ ] CI: periodic_tests.jl