### PR TITLE
Enforce strict callback documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,13 +13,12 @@ makedocs(
     sitename = "DiffEqCallbacks.jl",
     authors = "Chris Rackauckas",
     modules = [DiffEqCallbacks],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     linkcheck_ignore = [
         "https://www.sciencedirect.com/science/article/pii/S0096300304009683",
         "http://mathworld.wolfram.com/ShadowingTheorem.html",
         "https://www.mathworks.com/help/matlab/math/nonnegative-ode-solution.html",
     ],
-    warnonly = [:missing_docs],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/DiffEqCallbacks/stable/"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -9,4 +9,5 @@ pages = [
     "step_control.md",
     "projection.md",
     "uncertainty_quantification.md",
+    "internals.md",
 ]

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,31 @@
+# Internal Implementations
+
+The bindings on this page are implementation details used by DiffEqCallbacks itself.
+They are not supported extension points or stable user-facing APIs. Do not build
+downstream packages on them; use the documented callback constructors instead.
+
+```@docs
+DiffEqCallbacks.CachePool
+DiffEqCallbacks.IndependentlyLinearizedSolutionChunks
+DiffEqCallbacks.affect!
+DiffEqCallbacks.allocate_vjp
+DiffEqCallbacks.allocate_zeros
+DiffEqCallbacks.g_weights
+DiffEqCallbacks.gauss_points
+DiffEqCallbacks.gauss_weights
+DiffEqCallbacks.gk_points
+DiffEqCallbacks.gk_weights
+DiffEqCallbacks.isaccepted
+DiffEqCallbacks.modify_u!
+DiffEqCallbacks.recursive_add!
+DiffEqCallbacks.recursive_adjoint
+DiffEqCallbacks.recursive_copy
+DiffEqCallbacks.recursive_copyto!
+DiffEqCallbacks.recursive_neg!
+DiffEqCallbacks.recursive_sub!
+DiffEqCallbacks.recursive_zero!
+DiffEqCallbacks.sample!
+DiffEqCallbacks.seek_forward
+DiffEqCallbacks.setup
+DiffEqCallbacks.store!
+```

--- a/src/autoabstol.jl
+++ b/src/autoabstol.jl
@@ -26,29 +26,27 @@ function AutoAbstol_initialize(cb, u, t, integrator)
 end
 
 """
-```julia
-AutoAbstol(save = true; init_curmax = 1e-6)
-```
+    AutoAbstol(save = true; init_curmax = 0.0) -> DiscreteCallback
 
-Provides a way to automatically adapt the absolute tolerance to the problem. This
-helps the solvers automatically “learn” what appropriate limits are. This callback set
-starts the absolute tolerance at `init_curmax` (default `1e-6`), and at each iteration it
-is set to the maximum value that the state has thus far reached times the relative tolerance.
+Construct a callback that updates `integrator.opts.abstol` after every accepted step to the
+largest magnitude observed in the state so far, multiplied by `integrator.opts.reltol`.
 
-## Keyword Arguments
+# Arguments
 
-  - `save` determines whether this callback has saving enabled
-  - `init_curmax` is the initial `abstol`.
+  - `save::Bool = true`: save the solution immediately before the callback affect. Set this
+    to `false` when another callback controls saving.
 
-If this callback is used in isolation, `save=true` is required for normal saving behavior.
-Otherwise, `save=false` should be set to ensure extra saves do not occur.
+# Keywords
 
-## Returns
+  - `init_curmax = 0.0`: initial maximum state magnitude. A zero value is replaced during
+    initialization with the integrator's configured `abstol`; arrays update elementwise.
 
-A `DiscreteCallback` that updates the integrator absolute tolerance from the largest
-state magnitude observed so far.
+# Returns
 
-## Examples
+  - `DiscreteCallback`: a callback that updates the absolute tolerance, then marks
+    a derivative discontinuity after each affect.
+
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/integrating_GK_affect.jl
+++ b/src/integrating_GK_affect.jl
@@ -249,34 +249,32 @@ function (affect!::SavingIntegrandGKAffect)(integrator)
 end
 
 """
-```julia
-IntegratingGKCallback(integrand_func,
-    integrand_values::IntegrandValues, integrand_prototype)
-```
+    IntegratingGKCallback(integrand_func, integrand_values::IntegrandValues,
+        integrand_prototype, tol = 1.0e-7) -> DiscreteCallback
 
-Let one define a function `integrand_func(u, t, integrator)::typeof(integrand_prototype)` which
-returns Integral(integrand_func(u(t),t)dt) over the problem tspan.
+Construct a callback that uses adaptive Gauss-Kronrod quadrature to save one integral
+estimate over each accepted solver step in `integrand_values.integrand`.
 
-## Arguments
+# Arguments
 
-  - `integrand_func(out, u, t, integrator)` for in-place problems and `out = integrand_func(u, t, integrator)` for
-    out-of-place problems. Returns the quantity in the integral for computing dG/dp.
-    Note that for out-of-place problems, this should allocate the output (not as a view to `u`).
-  - `integrand_values::IntegrandValues` is the types that `integrand_func` will return, i.e.
-    `integrand_func(t, u, integrator)::integrandType`. It's specified via
-    `IntegrandValues(integrandType)`, i.e. give the type
-    that `integrand_func` will output (or higher compatible type).
-  - `integrand_prototype` is a prototype of the output from the integrand.
+  - `integrand_func`: for out-of-place problems, define
+    `integrand_func(u, t, integrator)` to return the integrand. For in-place problems,
+    define `integrand_func(out, u, t, integrator)` to write the integrand into `out`.
+    Returned values must be compatible with `integrand_values`.
+  - `integrand_values::IntegrandValues`: storage for accepted-step end times and quadrature
+    estimates. Construct it as `IntegrandValues(time_type, integrand_type)` with an
+    `integrand_type` that accepts the returned integrand values.
+  - `integrand_prototype`: representative integrand output used to allocate the
+    in-place cache.
+  - `tol::Real = 1.0e-7`: absolute error tolerance for adaptive quadrature on each accepted
+    solver step.
 
-The outputted values are saved into `integrand_values`. The values are found
-via `integrand_values.integrand`.
+# Returns
 
-## Returns
+  - `DiscreteCallback`: a callback that appends one Gauss-Kronrod estimate after
+    each accepted step.
 
-A `DiscreteCallback` that saves one Gauss-Kronrod quadrature estimate per
-accepted step.
-
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/integrating_GK_sum.jl
+++ b/src/integrating_GK_sum.jl
@@ -88,49 +88,43 @@ function (affect!::SavingIntegrandGKSumAffect)(integrator)
 end
 
 """
-```julia
-IntegratingGKSumCallback(integrand_func,
-    integrand_values::IntegrandValuesSum,
-    integrand_prototype,
-    tol = 1.0e-7;
-    integrand_inplace = nothing)
-```
+    IntegratingGKSumCallback(integrand_func, integrand_values::IntegrandValuesSum,
+        integrand_prototype, tol = 1.0e-7; integrand_inplace = nothing) -> DiscreteCallback
 
-Lets one define a function `integrand_func(u, t, integrator)` which
-returns Integral(integrand_func(u(t),t)dt over the problem tspan.
+Construct a callback that uses adaptive Gauss-Kronrod quadrature to accumulate the integral
+of `integrand_func` over accepted solver steps in `integrand_values.integrand`.
 
-## Arguments
+# Arguments
 
-  - `integrand_func(out, u, t, integrator)` for in-place problems and `out = integrand_func(u, t, integrator)` for
-    out-of-place problems. Returns the quantity in the integral for computing dG/dp.
-    Note that for out-of-place problems, this should allocate the output (not as a view to `u`).
-  - `integrand_values::IntegrandValues` is the types that `integrand_func` will return, i.e.
-    `integrand_func(t, u, integrator)::integrandType`. It's specified via
-    `IntegrandValues(integrandType)`, i.e. give the type
-    that `integrand_func` will output (or higher compatible type).
-  - `integrand_prototype` is a prototype of the output from the integrand.
+  - `integrand_func`: define either `integrand_func(u, t, integrator)` to return the
+    integrand or `integrand_func(out, u, t, integrator)` to write it into `out`. Returned or
+    written values must be compatible with `integrand_values.integrand`.
+  - `integrand_values::IntegrandValuesSum`: storage for the running integral. Construct it
+    as
+    `IntegrandValuesSum(initial_value)` with an initial value compatible with the integrand.
+  - `integrand_prototype`: representative integrand output used as an in-place output
+    buffer.
+  - `tol::Real = 1.0e-7`: absolute error tolerance for adaptive quadrature on each accepted
+    solver step.
 
-## Keyword Arguments
+# Keywords
 
-  - `integrand_inplace = nothing`: controls which form of `integrand_func` is called.
-    With the default `nothing`, the in-place `integrand_func(out, u, t, integrator)`
-    form is used for in-place problems (when an `integrand_prototype` is given) and
-    the allocating `integrand_func(u, t, integrator)` form for out-of-place problems.
-    Pass `integrand_inplace = true` to force the in-place form even for out-of-place
-    problems — the integrand output (e.g. a parameter-shaped buffer) may be mutable
-    even when the state is immutable, which avoids allocating the output on every
-    quadrature node. Requires an `integrand_prototype`. Pass `integrand_inplace = false`
-    to force the allocating form.
+  - `integrand_inplace::Union{Nothing, Bool} = nothing`: select the integrand calling form.
+    With `nothing`, use the in-place form for an in-place problem when a cache can be
+    allocated, and otherwise use the allocating form. Set this to `true` to force the
+    in-place form or `false` to force the allocating form. `true` requires a non-`nothing`
+    `integrand_prototype`.
 
-The outputted values are saved into `integrand_values`. The values are found
-via `integrand_values.integrand`.
+# Returns
 
-## Returns
+  - `DiscreteCallback`: a callback that adds each Gauss-Kronrod estimate to
+    `integrand_values.integrand`.
 
-A `DiscreteCallback` that accumulates Gauss-Kronrod quadrature estimates into
-`integrand_values.integrand`.
+# Throws
 
-## Examples
+  - `ArgumentError`: if `integrand_inplace = true` and `integrand_prototype === nothing`.
+
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/integrating_sum.jl
+++ b/src/integrating_sum.jl
@@ -135,48 +135,41 @@ function (affect!::SavingIntegrandSumAffect)(integrator)
 end
 
 """
-```julia
-IntegratingSumCallback(integrand_func,
-    integrand_values::IntegrandValuesSum,
-    integrand_prototype;
-    integrand_inplace = nothing)
-```
+    IntegratingSumCallback(integrand_func, integrand_values::IntegrandValuesSum,
+        integrand_prototype; integrand_inplace = nothing) -> DiscreteCallback
 
-Lets one define a function `integrand_func(u, t, integrator)` which
-returns Integral(integrand_func(u(t),t)dt over the problem tspan.
+Construct a callback that uses fixed-order Gaussian quadrature to accumulate the integral of
+`integrand_func` over accepted solver steps in `integrand_values.integrand`.
 
-## Arguments
+# Arguments
 
-  - `integrand_func(out, u, t, integrator)` for in-place problems and `out = integrand_func(u, t, integrator)` for
-    out-of-place problems. Returns the quantity in the integral for computing dG/dp.
-    Note that for out-of-place problems, this should allocate the output (not as a view to `u`).
-  - `integrand_values::IntegrandValues` is the types that `integrand_func` will return, i.e.
-    `integrand_func(t, u, integrator)::integrandType`. It's specified via
-    `IntegrandValues(integrandType)`, i.e. give the type
-    that `integrand_func` will output (or higher compatible type).
-  - `integrand_prototype` is a prototype of the output from the integrand.
+  - `integrand_func`: define either `integrand_func(u, t, integrator)` to return the
+    integrand or `integrand_func(out, u, t, integrator)` to write it into `out`. Returned or
+    written values must be compatible with `integrand_values.integrand`.
+  - `integrand_values::IntegrandValuesSum`: storage for the running integral. Construct it
+    as
+    `IntegrandValuesSum(initial_value)` with an initial value compatible with the integrand.
+  - `integrand_prototype`: representative integrand output used as an in-place output
+    buffer.
 
-## Keyword Arguments
+# Keywords
 
-  - `integrand_inplace = nothing`: controls which form of `integrand_func` is called.
-    With the default `nothing`, the in-place `integrand_func(out, u, t, integrator)`
-    form is used for in-place problems (when an `integrand_prototype` is given) and
-    the allocating `integrand_func(u, t, integrator)` form for out-of-place problems.
-    Pass `integrand_inplace = true` to force the in-place form even for out-of-place
-    problems — the integrand output (e.g. a parameter-shaped buffer) may be mutable
-    even when the state is immutable, which avoids allocating the output on every
-    quadrature node. Requires an `integrand_prototype`. Pass `integrand_inplace = false`
-    to force the allocating form.
+  - `integrand_inplace::Union{Nothing, Bool} = nothing`: select the integrand calling form.
+    With `nothing`, use the in-place form for an in-place problem when a cache can be
+    allocated, and otherwise use the allocating form. Set this to `true` to force the
+    in-place form or `false` to force the allocating form. `true` requires a non-`nothing`
+    `integrand_prototype`.
 
-The outputted values are saved into `integrand_values`. The values are found
-via `integrand_values.integrand`.
+# Returns
 
-## Returns
+  - `DiscreteCallback`: a callback that adds each Gaussian quadrature estimate to
+    `integrand_values.integrand`.
 
-A `DiscreteCallback` that accumulates the quadrature estimate into
-`integrand_values.integrand`.
+# Throws
 
-## Examples
+  - `ArgumentError`: if `integrand_inplace = true` and `integrand_prototype === nothing`.
+
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -1,28 +1,34 @@
 """
     IterativeCallback(time_choice, user_affect!, tType = Float64;
-        initial_affect = false, kwargs...)
+        initial_affect = false, initialize = ..., kwargs...) -> DiscreteCallback
 
-A callback to be used to iteratively apply some affect. For example, if given the first
-effect at `t₁`, you can define `t₂` to apply the next effect.
+Construct a callback that applies `user_affect!` at the sequence of integration times
+returned by `time_choice`.
 
-## Arguments
+# Arguments
 
-  - `time_choice(integrator)` determines the time of the next callback. If `nothing` is
-    returned for the time choice, then the iterator ends.
-  - `user_affect!` is the effect applied to the integrator at the stopping points.
+  - `time_choice`: a function `time_choice(integrator)` that returns the next callback
+    time or `nothing` to stop scheduling further affects.
+  - `user_affect!`: a function `user_affect!(integrator)` applied at each scheduled time.
+  - `tType::Type = Float64`: type used to store the next callback time. Set this to the
+    problem time type when it is not `Float64`.
 
-## Keyword Arguments
+# Keywords
 
-  - `initial_affect` is whether to apply the affect at `t=0` which defaults to `false`
-  - `initialize` is the callback initialization function.
-  - `kwargs` are keyword arguments accepted by `DiscreteCallback`.
+  - `initial_affect::Bool = false`: apply `user_affect!` during callback initialization
+    at the initial integration time before asking `time_choice` for the next time.
+  - `initialize = ...`: callback initialization function called as
+    `initialize(callback, u, t, integrator)` before the initial affect or first scheduled
+    stop.
+    By default, it marks a derivative discontinuity according to `initial_affect`.
+  - `kwargs...`: keyword arguments forwarded to `DiscreteCallback`.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that repeatedly schedules the next time returned by
-`time_choice`.
+  - `DiscreteCallback`: a callback that schedules each time returned by `time_choice`
+    until it returns `nothing`.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq
@@ -143,38 +149,40 @@ end
 
 """
     PeriodicCallback(f, Δt::Number; phase = 0, initial_affect = false,
-        final_affect = false, kwargs...)
+        final_affect = false, initialize = ..., kwargs...) -> DiscreteCallback
 
-`PeriodicCallback` can be used when a function should be called periodically in terms of
-integration time (as opposed to wall time), i.e. at `t = tspan[1]`, `t = tspan[1] + Δt`,
-`t = tspan[1] + 2Δt`, and so on.
+Construct a callback that applies `f` at regular intervals of integration time. Scheduled
+stops are separated by `Δt` and are offset from the initial time by `phase`. When
+`initial_affect = true`, `f` is also applied during callback initialization.
 
-If a non-zero `phase` is provided, the invocations of the callback will be shifted by
-`phase` time units, i.e., the calls will occur at
-`t = tspan[1] + phase`, `t = tspan[1] + phase + Δt`,
-`t = tspan[1] + phase + 2Δt`, and so on.
+# Arguments
 
-This callback can, for example, be used to model a
-discrete-time controller for a continuous-time system, running at a fixed rate.
+  - `f`: a function `f(integrator)` applied at each periodic stop.
+  - `Δt::Number`: signed integration-time period. Its sign must match the integration
+    direction.
 
-## Arguments
+# Keywords
 
-  - `f` the `affect!(integrator)` function to be called periodically
-  - `Δt` is the period
+  - `phase = 0`: nonnegative offset of scheduled periodic stops from the initial integration
+    time. A negative phase throws an `ArgumentError`.
+  - `initial_affect::Bool = false`: apply `f` during callback initialization at the initial
+    integration time.
+  - `final_affect::Bool = false`: apply `f` when the integrator finishes, even when the
+    final time is not a periodic stop.
+  - `initialize = ...`: callback initialization function called as
+    `initialize(callback, u, t, integrator)` before periodic stops are scheduled. By
+    default, it marks a derivative discontinuity according to `initial_affect`.
+  - `kwargs...`: keyword arguments forwarded to `DiscreteCallback`.
 
-  ## Keyword Arguments
+# Returns
 
-  - `phase` is a phase offset
-  - `initial_affect` is whether to apply the affect at the initial time, which defaults to `false`
-  - `final_affect` is whether to apply the affect at the final time, which defaults to `false`
-  - `kwargs` are keyword arguments accepted by the `DiscreteCallback` constructor.
+  - `DiscreteCallback`: a callback that schedules `f` at periodic integration-time stops.
 
-## Returns
+# Throws
 
-A `DiscreteCallback` that schedules an `affect!` call every `Δt` units of
-integration time.
+  - `ArgumentError`: if `phase < 0`.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/preset_time.jl
+++ b/src/preset_time.jl
@@ -32,33 +32,38 @@ function (f::PresetTimeFunction)(c, u, t, integrator)
 end
 
 """
-    PresetTimeCallback(tstops, user_affect!;
-        initialize = INITIALIZE_DEFAULT,
-        filter_tstops = true,
-        kwargs...)
+    PresetTimeCallback(tstops, user_affect!; initialize = INITIALIZE_DEFAULT,
+        filter_tstops = true, sort_inplace = false, kwargs...) -> DiscreteCallback
 
-A callback that adds callback `affect!` calls at preset times. No playing around with
-`tstops` or anything is required: this callback adds the triggers for you to make it
-automatic.
+Construct a callback that schedules `user_affect!` at the supplied integration-time stops.
 
-## Arguments
+# Arguments
 
-  - `tstops`: the times for the `affect!` to trigger at.
-  - `user_affect!`: an `affect!(integrator)` function to use at the time points.
+  - `tstops::Union{Number, AbstractVector}`: one time or a collection of callback times.
+    Vector inputs are sorted before use.
+  - `user_affect!`: a function `user_affect!(integrator)` applied at each scheduled stop.
 
-## Keyword Arguments
+# Keywords
 
-  - `filter_tstops`: Whether to filter out tstops beyond the end of the integration timespan.
-    Defaults to true. If false, then tstops can extend the interval of integration.
-  - `initialize`: callback initialization function.
-  - `kwargs`: keyword arguments forwarded to `DiscreteCallback`.
+  - `initialize = INITIALIZE_DEFAULT`: callback initialization function called as
+    `initialize(callback, u, t, integrator)` before the stops are scheduled.
+  - `filter_tstops::Bool = true`: schedule only stops strictly inside the integration
+    interval. Set this to `false` to schedule all supplied stops, including values outside
+    that interval.
+  - `sort_inplace::Bool = false`: sort a vector `tstops` in place. By default, sort a
+    copy and leave the supplied vector unchanged.
+  - `kwargs...`: keyword arguments forwarded to `DiscreteCallback`.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that schedules the requested `tstops` and calls `user_affect!`
-at those times.
+  - `DiscreteCallback`: a callback that schedules the requested stops and calls
+    `user_affect!`.
 
-## Examples
+# Throws
+
+  - `ArgumentError`: if `tstops` is neither a number nor a vector.
+
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq


### PR DESCRIPTION
## Summary
- enable default Documenter doctests and missing-public-doc enforcement
- make affected public callback docstrings definition-point, SciMLStyle-compliant API references
- document exact positional arguments, keywords, return values, failure modes, and examples

## Local verification
- `julia +1.12 --project=docs docs/make.jl`
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
- Runic and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.