### PR TITLE
QA: scan the Functors package extension

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,12 +1,14 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+Functors = "0.5"
 JET = "0.9, 0.10, 0.11"
 SciMLTesting = "2.4"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,15 @@
-using SciMLTesting, DiffEqCallbacks
+using SciMLTesting, DiffEqCallbacks, Test
 
 # Package extensions only exist as modules once their trigger weakdep is loaded, and
 # ExplicitImports skips extensions it cannot resolve via `Base.get_extension`. Loading
 # Functors here is what puts `DiffEqCallbacksFunctorsExt` in scope for the QA checks.
 using Functors
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(DiffEqCallbacks, :DiffEqCallbacksFunctorsExt) !== nothing
+end
 
 run_qa(
     DiffEqCallbacks;

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,10 @@
 using SciMLTesting, DiffEqCallbacks
 
+# Package extensions only exist as modules once their trigger weakdep is loaded, and
+# ExplicitImports skips extensions it cannot resolve via `Base.get_extension`. Loading
+# Functors here is what puts `DiffEqCallbacksFunctorsExt` in scope for the QA checks.
+using Functors
+
 run_qa(
     DiffEqCallbacks;
     ei_kwargs = (;
@@ -14,6 +19,38 @@ run_qa(
             ignore = (
                 :QRCompactWY,  # LinearAlgebra internal concrete factorization type
                 :RefValue,     # Base internal concrete Ref type
+            ),
+        ),
+        # `DiffEqCallbacksFunctorsExt` exists to implement DiffEqCallbacks' own internal
+        # recursive-container generics for `Functors`-traversable parameters, so it must
+        # import them from the parent package; they are deliberately internal and have no
+        # public spelling. ExplicitImports' `allow_internal_imports` does not cover this
+        # because it exempts only imports sharing a `Base.moduleroot`, and an extension
+        # module is its own root rather than the parent package's.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :allocate_vjp,
+                :allocate_vjp_internal,
+                :allocate_zeros,
+                :internal_add!,
+                :internal_adjoint,
+                :internal_allocate_zeros,
+                :internal_axpy!,
+                :internal_copy,
+                :internal_copyto!,
+                :internal_neg!,
+                :internal_scalar_mul!,
+                :internal_sub!,
+                :internal_zero!,
+                :recursive_add!,
+                :recursive_adjoint,
+                :recursive_axpy!,
+                :recursive_copy,
+                :recursive_copyto!,
+                :recursive_neg!,
+                :recursive_scalar_mul!,
+                :recursive_sub!,
+                :recursive_zero!,
             ),
         ),
     ),


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

`run_qa` runs ExplicitImports' checks over the package module *and its extensions* — ExplicitImports reads the `[extensions]` table from `Project.toml` and adds each one — but only when the extension module actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep is loaded, and the QA environment loaded none. So `DiffEqCallbacksFunctorsExt` was never checked by QA.

Note the failure mode is **silent**: an unresolvable extension is skipped and the checks still report a clean pass.

## Change

* `test/qa/Project.toml`: add `Functors` (same UUID as the root `[weakdeps]` entry) with `compat = "0.5"`, mirroring the root `[compat]`.
* `test/qa/qa.jl`: `using Functors` before `run_qa`, with a comment explaining why.
* `test/qa/qa.jl`: a load guard asserting the extension module really exists, so a future break in the extension's precompilation fails QA instead of silently reverting coverage to zero:

```julia
# ExplicitImports silently skips an extension that fails to load, so assert the
# extension modules actually exist rather than trusting a green run_qa.
@testset "Extensions loaded" begin
    @test Base.get_extension(DiffEqCallbacks, :DiffEqCallbacksFunctorsExt) !== nothing
end
```

That guard matters more than usual here, since the 22 ignore entries below are all justified by the extension being scanned.

## Proof the extension is actually scanned now

A passing QA summary is not proof — each ExplicitImports check folds all submodules into a single `@test`, so a clean extension yields an identical summary either way. Run directly against the QA environment:

```
$ julia --project=test/qa -e 'using DiffEqCallbacks, Functors, SciMLTesting
      const EI = SciMLTesting.ExplicitImports
      println("get_extension => ", Base.get_extension(DiffEqCallbacks, :DiffEqCallbacksFunctorsExt))
      println("modules scanned: ", first.(EI.explicit_imports(DiffEqCallbacks)))'
get_extension => DiffEqCallbacksFunctorsExt
modules scanned: Module[DiffEqCallbacksFunctorsExt, DiffEqCallbacks]
```

versus the same script without `Functors` (i.e. what `master` does today):

```
get_extension => nothing
modules scanned: Module[DiffEqCallbacks]
```

The first QA run after adding the weakdep also errored with 22 new `all_explicit_imports_are_public` findings from `ext/DiffEqCallbacksFunctorsExt.jl`, which is independent confirmation that the extension entered the checked set.

## Coverage

| Extension | Status |
|---|---|
| `DiffEqCallbacksFunctorsExt` (trigger: `Functors`) | now scanned, and guarded |

That is the package's only extension, so coverage is complete — nothing is left out for GPU-hardware, external-system-library, or resolution reasons.

## Ignore entries added

One block, under `all_explicit_imports_are_public`, covering 22 symbols:

`allocate_vjp`, `allocate_vjp_internal`, `allocate_zeros`, `internal_add!`, `internal_adjoint`, `internal_allocate_zeros`, `internal_axpy!`, `internal_copy`, `internal_copyto!`, `internal_neg!`, `internal_scalar_mul!`, `internal_sub!`, `internal_zero!`, `recursive_add!`, `recursive_adjoint`, `recursive_axpy!`, `recursive_copy`, `recursive_copyto!`, `recursive_neg!`, `recursive_scalar_mul!`, `recursive_sub!`, `recursive_zero!`

Justification: every one of these is a `DiffEqCallbacks` *internal* generic that the extension imports from its own parent package in order to add `Functors`-traversable methods to it — that is the entire purpose of the extension. There is no public spelling, and promoting 22 internal recursive-container helpers to public API (which under the SciML rules would also require docstrings and rendered docs entries, plus a SemVer commitment) would be the wrong fix. Qualifying instead of importing (`DiffEqCallbacks.recursive_copyto!(y, x) = ...`) just moves the same finding to `all_qualified_accesses_are_public`.

ExplicitImports' `allow_internal_imports = true` is meant to exempt exactly this kind of same-package import, but it tests `Base.moduleroot(mod) == Base.moduleroot(importing_from)`, and an extension module is its own `moduleroot` rather than the parent package's — so parent-package imports from an extension are not recognised as internal. Arguably worth an upstream issue on ExplicitImports.jl; ignoring here in the meantime.

No check was disabled, no `@test_broken` / `@test_skip` was added.

## Extension source changes

None. The findings were all the unavoidable parent-package-internals class above; there were no `no_implicit_imports` or `*_via_owners` findings to fix.

## Local result

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary:   | Pass  Total  Time
QA/jet_tests.jl |   15     15  7.5s
Test Summary: | Pass  Total     Time
QA/qa.jl      |   22     22  1m51.4s
     Testing DiffEqCallbacks tests passed
```

Julia 1.12. The `QA/qa.jl` count went `20 passed + 1 errored` (weakdep added, before the ignore block) → `21` (ignores added) → `22` (load guard added), the last increment being the new `Extensions loaded` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
