### PR TITLE
Complete public callback API documentation

### DIFF
--- a/src/autoabstol.jl
+++ b/src/autoabstol.jl
@@ -43,8 +43,8 @@ largest magnitude observed in the state so far, multiplied by `integrator.opts.r
 
 # Returns
 
-  - `DiscreteCallback`: a callback that updates the absolute tolerance, then marks
-    a derivative discontinuity after each affect.
+  - `DiscreteCallback`: a callback that updates the absolute tolerance after each accepted
+    step without marking the state as modified.
 
 # Examples
 

--- a/src/domain.jl
+++ b/src/domain.jl
@@ -222,8 +222,8 @@ end
 """
     GeneralDomain(
         g, u = nothing; save = true, abstol = nothing, scalefactor = nothing,
-        autonomous = nothing, domain_jacobian = nothing,
-        nlsolve_kwargs = (; abstol = 10 * eps()), kwargs...)
+        autonomous = nothing, domain_jacobian = nothing, manifold_jacobian = missing,
+        nlsolve_kwargs = (; abstol = 10 * eps()), kwargs...) -> CallbackSet
 
 A `GeneralDomain` callback in DiffEqCallbacks.jl generalizes the concept of
 a `PositiveDomain` callback to arbitrary domains.
@@ -244,49 +244,68 @@ desired domain, but in contrast to a `PositiveDomain` callback the nonlinear sol
 `ManifoldProjection` cannot guarantee that all state vectors of the solution are actually
 inside the domain. Thus, a `PositiveDomain` callback should generally be preferred.
 
-## Arguments
+# Arguments
 
   - `g`: the implicit definition of the domain as a function as described above which is
     zero when the value is in the domain.
-  - `u`: A prototype of the state vector of the integrator. A copy of it is saved and
+  - `u = nothing`: a prototype of the state vector of the integrator. A copy is saved and
     extrapolated values are written to it. If it is not specified,
     every application of the callback allocates a new copy of the state vector.
 
-## Keyword Arguments
+# Keywords
 
-  - `save`: Whether to do the standard saving (applied after the callback).
-  - `abstol`: Tolerance up to, which residuals are accepted. Element-wise tolerances
-    are allowed. If it is not specified, every application of the callback uses the
-    current absolute tolerances of the integrator.
-  - `scalefactor`: Factor by which an unaccepted time step is reduced. If it is not
-    specified, time steps are halved.
-  - `autonomous`: Whether `g` is an autonomous function of the form `g(resid, u, p)`.
+  - `save::Bool = true`: whether to save immediately after applying the domain callback.
+  - `abstol = nothing`: tolerance below which residuals are accepted. Element-wise
+    tolerances are allowed. If it is not specified, every application of the callback uses
+    the current absolute tolerances of the integrator.
+  - `scalefactor = nothing`: factor by which an unaccepted time step is reduced. If it is
+    not specified, time steps are halved.
+  - `autonomous = nothing`: whether `g` is an autonomous function of the form
+    `g(resid, u, p)` or `g(u, p)`.
     If it is not specified, it is determined automatically.
-  - `kwargs`: All other keyword arguments are passed to [`ManifoldProjection`](@ref).
-  - `nlsolve_kwargs`: All keyword arguments are passed to the nonlinear solver in
+  - `domain_jacobian = nothing`: analytic Jacobian of `g` with respect to the state, using
+    the same calling form as `g` and a leading Jacobian output for an in-place problem.
+  - `manifold_jacobian = missing`: unsupported compatibility keyword. Supplying any value
+    throws an `ArgumentError`; use `domain_jacobian` instead.
+  - `nlsolve_kwargs = (; abstol = 10 * eps())`: keywords passed to the nonlinear solver in
     `ManifoldProjection`. The default is `(; abstol = 10 * eps())`.
-  - `domain_jacobian`: The Jacobian of the domain (wrt the state). This has the same
-    signature as `g` and the first argument is the Jacobian if inplace. This corresponds to
-    the `manifold_jacobian` argument of [`ManifoldProjection`](@ref). Note that passing
-    a `manifold_jacobian` is not supported for `GeneralDomain` and results in an error.
+  - `kwargs...`: additional keywords passed to [`ManifoldProjection`](@ref), including
+    `autodiff`, `nlsolve`, and `resid_prototype`. Either `domain_jacobian` or `autodiff`
+    must be provided.
 
-## References
+# Returns
+
+  - `CallbackSet`: a manifold projection followed by a discrete callback that restricts the
+    proposed step to the requested domain.
+
+# Throws
+
+  - `ArgumentError`: if `manifold_jacobian` is supplied, or if the callback is applied with
+    a non-adaptive integrator.
+  - `DimensionMismatch`: if an element-wise `abstol` does not match the residual length.
+  - `ErrorException`: during callback initialization if both `domain_jacobian` and the
+    forwarded `autodiff` keyword are `nothing`.
+
+# References
 
 Shampine, Lawrence F., Skip Thompson, Jacek Kierzenka and G. D. Byrne.
 Non-negative solutions of ODEs. Applied Mathematics and Computation 170
 (2005): 556-569.
 
-## Examples
+# Examples
 
 ```julia
-using DiffEqCallbacks, OrdinaryDiffEq
+using ADTypes, DiffEqCallbacks, OrdinaryDiffEq
 
 function nonnegative_residual(resid, u, p, t)
     @. resid = max(-u, 0)
 end
 
 prob = ODEProblem((du, u, p, t) -> (du .= -u), [1.0, 2.0], (0.0, 2.0))
-cb = GeneralDomain(nonnegative_residual, [1.0, 2.0]; abstol = 1.0e-8)
+cb = GeneralDomain(
+    nonnegative_residual, [1.0, 2.0]; abstol = 1.0e-8,
+    autodiff = AutoForwardDiff()
+)
 sol = solve(prob, Tsit5(); callback = cb)
 ```
 """
@@ -320,26 +339,30 @@ function GeneralDomain(
 end
 
 """
-    PositiveDomain(u = nothing; save = true, abstol = nothing, scalefactor = nothing)
+    PositiveDomain(u = nothing; save = true, abstol = nothing,
+        scalefactor = nothing) -> DiscreteCallback
 
 Especially in biology and other natural sciences, a desired property of
 dynamical systems is the positive invariance of the positive cone, i.e.
 non-negativity of variables at time ``t_0`` ensures their non-negativity at times
 ``t \\geq t_0`` for which the solution is defined. However, even if a system
 satisfies this property mathematically it can be difficult for ODE solvers to
-ensure it numerically, as these [MATLAB examples](https://www.mathworks.com/help/matlab/math/nonnegative-ode-solution.html)
+ensure it numerically, as these
+[MATLAB examples](https://www.mathworks.com/help/matlab/math/nonnegative-ode-solution.html)
 show.
 
 To deal with this problem, one can specify `isoutofdomain=(u,p,t) -> any(x
--> x < 0, u)` as additional [solver option](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/),
-which will reject any step that leads to non-negative values and reduce the next
-time step. However, since this approach only rejects steps and hence
+-> x < 0, u)` as an additional
+[solver option](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/), which
+will reject any step that leads to negative values and reduce the next time step.
+However, since this approach only rejects steps and hence
 calculations might be repeated multiple times until a step is accepted, it can
 be computationally expensive.
 
 Another approach is taken by a `PositiveDomain` callback in
 DiffEqCallbacks.jl, which is inspired by
-[Shampine's et al. paper about non-negative ODE solutions](https://www.sciencedirect.com/science/article/pii/S0096300304009683).
+[Shampine et al.'s paper about non-negative ODE
+solutions](https://www.sciencedirect.com/science/article/pii/S0096300304009683).
 It reduces the next step by a certain scale factor until the extrapolated value
 at the next time point is non-negative with a certain tolerance. Extrapolations
 are cheap to compute but might be inaccurate, so if a time step is changed it
@@ -357,34 +380,44 @@ derivative ``x'_i`` of a negative component ``x_i`` to ``\\max \\{0, f_i(x, t)\\
 where ``t`` denotes the current time point with state vector ``x`` and ``f_i``
 is the ``i``-th component of function ``f`` in an ODE system ``x' = f(x, t)``.
 
-## Arguments
+# Arguments
 
-- `u`: A prototype of the state vector of the integrator. A copy of it is saved and
-  extrapolated values are written to it. If it is not specified,
-  every application of the callback allocates a new copy of the state vector.
+  - `u = nothing`: a prototype of the state vector of the integrator. A copy is saved and
+    extrapolated values are written to it. If it is not specified, every application of the
+    callback allocates a new copy of the state vector.
 
-## Keyword Arguments
+# Keywords
 
-- `save`: Whether to do the standard saving (applied after the callback).
-- `abstol`: Tolerance up to, which negative extrapolated values are accepted.
-  Element-wise tolerances are allowed. If it is not specified, every application
-  of the callback uses the current absolute tolerances of the integrator.
-- `scalefactor`: Factor by which an unaccepted time step is reduced. If it is not
-  specified, time steps are halved.
+  - `save::Bool = true`: whether to save immediately after applying the domain callback.
+  - `abstol = nothing`: tolerance above the negative of which extrapolated values are
+    accepted. Element-wise tolerances are allowed. If it is not specified, every application
+    of the callback uses the current absolute tolerances of the integrator.
+  - `scalefactor = nothing`: factor by which an unaccepted time step is reduced. If it is
+    not specified, time steps are halved.
 
-## References
+# Returns
+
+  - `DiscreteCallback`: a callback that restricts proposed steps to the positive domain and
+    replaces negative entries in each accepted state with zero.
+
+# Throws
+
+  - `ArgumentError`: if the callback is applied with a non-adaptive integrator.
+  - `DimensionMismatch`: if an element-wise `abstol` does not match the state length.
+
+# References
 
 Shampine, Lawrence F., Skip Thompson, Jacek Kierzenka and G. D. Byrne.
 Non-negative solutions of ODEs. Applied Mathematics and Computation 170
 (2005): 556-569.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq
 
 f(u, p, t) = -u
-prob = ODEProblem(f, 1.0, (0.0, 2.0))
+prob = ODEProblem(f, [1.0], (0.0, 2.0))
 cb = PositiveDomain()
 
 sol = solve(prob, Tsit5(); callback = cb)

--- a/src/function_caller.jl
+++ b/src/function_caller.jl
@@ -64,28 +64,31 @@ end
         funcat = Vector{Float64}(),
         func_everystep = isempty(funcat),
         func_start = true,
-        tdir = 1)
+        tdir = 1) -> DiscreteCallback
 
 The function calling callback lets you define a function `func(u,t,integrator)`
 which gets called at the time points of interest.
 
-## Arguments
+# Arguments
 
-  - `func(u, t, integrator)` is the function to be called.
+  - `func`: function called as `func(u, t, integrator)` at each selected time. Its return
+    value is ignored, and it should not modify `u` or the integrator.
 
-## Keyword Arguments
+# Keywords
 
-  - `funcat` values or interval that the function is sure to be evaluated at.
-  - `func_everystep` whether to call the function after each integrator step.
-  - `func_start` whether the function is called at the initial condition.
-  - `tdir` should be `sign(tspan[end]-tspan[1])`. It defaults to `1` and should
-    be adapted if `tspan[1] > tspan[end]`.
+  - `funcat = Vector{Float64}()`: selected integration times, or a scalar interval at which
+    to call `func` throughout the problem time span.
+  - `func_everystep::Bool = isempty(funcat)`: whether to call `func` after every accepted
+    step.
+  - `func_start::Bool = true`: whether to call `func` at the initial condition.
+  - `tdir = 1`: integration direction used to order `funcat`. Set this to
+    `sign(tspan[end] - tspan[1])` for reverse-time problems.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that calls `func` without modifying the integrator state.
+  - `DiscreteCallback`: a callback that calls `func` without modifying the integrator state.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/independentlylinearizedutils.jl
+++ b/src/independentlylinearizedutils.jl
@@ -156,47 +156,52 @@ function store!(
 end
 
 """
-    IndependentlyLinearizedSolution
-    IndependentlyLinearizedSolution(prob::SciMLBase.AbstractDEProblem, num_derivatives = 0)
+    IndependentlyLinearizedSolution{T, S}
+    IndependentlyLinearizedSolution(prob::SciMLBase.AbstractDEProblem,
+        num_derivatives = 0) -> IndependentlyLinearizedSolution
 
-Efficient datastructure that holds a set of independently linearized solutions
-(obtained via the `LinearizingSavingCallback`) with related, but slightly
-different time vectors.  Stores a single time vector with a packed `BitMatrix`
-denoting which `u` vectors are sampled at which timepoints.  Provides an
-efficient `iterate()` method that can be used to reconstruct coherent views
-of the state variables at all timepoints, as well as an efficient `sample!()`
-method that can sample at arbitrary timesteps.
+Efficient storage for independently linearized state components obtained from
+[`LinearizingSavingCallback`](@ref). It stores a single time vector with a packed
+`BitMatrix` denoting which state components were sampled at each time and implements Julia's
+iteration interface to reconstruct a coherent state at every stored time.
 
-## Fields
+# Fields
 
   - `ts::Vector{T}`: sorted union of the stored time points.
   - `us::Vector{Matrix{S}}`: state and derivative samples. Each matrix corresponds to one
-    state component and contains its available samples in columns.
-  - `time_mask::BitMatrix`: maps rows of `us` to entries in `ts`; use iteration or `sample`
-    rather than interpreting this packed representation directly.
-  - `ilsc`: construction cache used while [`LinearizingSavingCallback`](@ref) is active.
-    It becomes `nothing` once the solve finishes and is not an extension point.
+    state component, uses rows for the primal and requested derivatives, and stores its
+    available time samples in columns.
+  - `time_mask::BitMatrix`: maps rows of `us` to entries in `ts`; use iteration rather than
+    interpreting this packed representation directly.
+The vectors and mask are storage owned by the callback. Iterate the result after the solve;
+do not mutate its fields while solving.
 
-The vectors and mask are storage owned by the callback. Read the result through the generic
-iteration and sampling operations after the solve; do not mutate its fields during solving.
-
-## Arguments
+# Arguments
 
   - `prob`: differential equation problem used to infer the time, state, and storage
     dimensions.
-  - `num_derivatives`: number of derivative rows to store in addition to the primal
-    state values.
+  - `num_derivatives::Int = 0`: nonnegative number of derivative rows to store in
+    addition to the primal state values.
 
-## Returns
+# Iteration
 
-An `IndependentlyLinearizedSolution` storage object for use with
-[`LinearizingSavingCallback`](@ref).
+Iteration yields `(t, values)` for each stored time, where `values` is a matrix with one row
+per state component and columns containing the primal followed by the requested derivatives.
 
-## Examples
+# Returns
+
+  - `IndependentlyLinearizedSolution`: storage to pass to
+    [`LinearizingSavingCallback`](@ref).
+
+# Examples
 
 ```julia
+using DiffEqCallbacks, OrdinaryDiffEq
+
+prob = ODEProblem((du, u, p, t) -> (du .= -u), [1.0, 2.0], (0.0, 1.0))
 ils = IndependentlyLinearizedSolution(prob)
-sol = solve(prob, solver; callback = LinearizingSavingCallback(ils))
+sol = solve(prob, Tsit5(); callback = LinearizingSavingCallback(ils))
+first_time, first_values = first(ils)
 ```
 """
 mutable struct IndependentlyLinearizedSolution{T, S}

--- a/src/integrating.jl
+++ b/src/integrating.jl
@@ -138,21 +138,21 @@ Storage used by [`IntegratingCallback`](@ref) and [`IntegratingGKCallback`](@ref
 one quadrature estimate per accepted solver step. Construct it before solving and pass the
 same instance to the callback; the callback appends to it in place.
 
-## Fields
+# Fields
 
   - `ts::Vector{tType}`: accepted-step end times associated with the stored estimates.
-  - `integrand::Vector{integrandType}`: quadrature estimates over the corresponding solver
-    steps. Entry `integrand[i]` approximates the integral from the previous saved solver time
-    to `ts[i]`.
+  - `integrand::Vector{integrandType}`: quadrature estimates over the corresponding
+    solver steps. Entry `integrand[i]` approximates the integral from the previous saved
+    solver time to `ts[i]`.
 
 Do not mutate either vector while a solve using the storage is active.
 
-## Constructors
+# Constructors
 
   - `IntegrandValues(tType, integrandType)`: create empty storage with time element type
     `tType` and estimate element type `integrandType`.
 
-## Example
+# Examples
 
 ```julia
 values = IntegrandValues(Float64, Float64)
@@ -168,14 +168,15 @@ end
 
 Create empty [`IntegrandValues`](@ref) storage.
 
-## Arguments
+# Arguments
 
   - `tType`: element type used for saved step end times.
   - `integrandType`: element type returned by the callback integrand function.
 
-## Returns
+# Returns
 
-An `IntegrandValues{tType, integrandType}` whose `ts` and `integrand` vectors are empty.
+  - `IntegrandValues{tType, integrandType}`: storage whose `ts` and `integrand` vectors are
+    empty.
 """
 function IntegrandValues(::Type{tType}, ::Type{integrandType}) where {tType, integrandType}
     return IntegrandValues{tType, integrandType}(Vector{tType}(), Vector{integrandType}())
@@ -244,33 +245,32 @@ function (affect!::SavingIntegrandAffect)(integrator)
 end
 
 """
-```julia
-IntegratingCallback(integrand_func,
-    integrand_values::IntegrandValues, integrand_prototype)
-```
+    IntegratingCallback(integrand_func, integrand_values::IntegrandValues,
+        integrand_prototype) -> DiscreteCallback
 
-Let one define a function `integrand_func(u, t, integrator)::typeof(integrand_prototype)` which
-returns Integral(integrand_func(u(t),t)dt over the problem tspan.
+Construct a callback that uses fixed-order Gaussian quadrature to save the integral of
+`integrand_func` over each accepted solver step. The callback appends the step end time to
+`integrand_values.ts` and the corresponding integral estimate to
+`integrand_values.integrand`.
 
-## Arguments
+# Arguments
 
-  - `integrand_func(out, u, t, integrator)` for in-place problems and `out = integrand_func(u, t, integrator)` for
-    out-of-place problems. Returns the quantity in the integral for computing dG/dp.
-    Note that for out-of-place problems, this should allocate the output (not as a view to `u`).
-  - `integrand_values::IntegrandValues` is the types that `integrand_func` will return, i.e.
-    `integrand_func(t, u, integrator)::integrandType`. It's specified via
-    `IntegrandValues(integrandType)`, i.e. give the type
-    that `integrand_func` will output (or higher compatible type).
-  - `integrand_prototype` is a prototype of the output from the integrand.
+  - `integrand_func`: for an out-of-place problem, define
+    `integrand_func(u, t, integrator)` to return the integrand. For an in-place problem,
+    define `integrand_func(out, u, t, integrator)` to write the integrand into `out`; when
+    `integrand_prototype === nothing`, the allocating three-argument form is used instead.
+    A returned value must not alias `u`.
+  - `integrand_values::IntegrandValues`: storage for accepted-step end times and quadrature
+    estimates. Its element types must accept the integration times and integrand outputs.
+  - `integrand_prototype`: representative integrand output used to allocate the in-place
+    output and accumulation buffers. Pass `nothing` to use the allocating form.
 
-The outputted values are saved into `integrand_values`. The values are found
-via `integrand_values.integrand`.
+# Returns
 
-## Returns
+  - `DiscreteCallback`: a callback that saves one Gaussian quadrature estimate per accepted
+    step.
 
-A `DiscreteCallback` that saves one quadrature estimate per accepted step.
-
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq
@@ -285,10 +285,10 @@ integrals_by_step = values.integrand
 
 !!! note
 
-    This method is currently limited to ODE solvers of order 10 or lower. Open an issue if other
-    solvers are required.
+    This method is currently limited to ODE solvers of order 10 or lower.
 
-    If `integrand_func` is in-place, you must use `cache` to store the output of `integrand_func`.
+    For the four-argument in-place form of `integrand_func`, pass an
+    `integrand_prototype` that can be used as its output buffer.
 """
 function IntegratingCallback(
         integrand_func, integrand_values::IntegrandValues, integrand_prototype

--- a/src/integrating_GK_affect.jl
+++ b/src/integrating_GK_affect.jl
@@ -274,6 +274,11 @@ estimate over each accepted solver step in `integrand_values.integrand`.
   - `DiscreteCallback`: a callback that appends one Gauss-Kronrod estimate after
     each accepted step.
 
+# Throws
+
+  - An exception when used with an `SDEProblem` or `RODEProblem`, for which this
+    Gauss-Kronrod algorithm is not guaranteed to converge.
+
 # Examples
 
 ```julia
@@ -291,10 +296,10 @@ integrals_by_step = values.integrand
 
     Method has automatic error control (h-adaptive quadrature).
 
-    This method is currently limited to ODE solvers of order 10 or lower. Open an issue if other
-    solvers are required.
+    This method is currently limited to ODE solvers of order 10 or lower.
 
-    If `integrand_func` is in-place, you must use `cache` to store the output of `integrand_func`.
+    For the four-argument in-place form of `integrand_func`, pass an
+    `integrand_prototype` that can be used as its output buffer.
 """
 function IntegratingGKCallback(
         integrand_func, integrand_values::IntegrandValues, integrand_prototype, tol = 1.0e-7

--- a/src/integrating_GK_sum.jl
+++ b/src/integrating_GK_sum.jl
@@ -123,6 +123,8 @@ of `integrand_func` over accepted solver steps in `integrand_values.integrand`.
 # Throws
 
   - `ArgumentError`: if `integrand_inplace = true` and `integrand_prototype === nothing`.
+  - An exception when used with an `SDEProblem` or `RODEProblem`, for which this
+    Gauss-Kronrod algorithm is not guaranteed to converge.
 
 # Examples
 
@@ -141,8 +143,7 @@ total = values.integrand
 
     This method uses Gauss-Kronrod quadrature rule to allow for error control.
 
-    This method is currently limited to ODE solvers of order 10 or lower. Open an issue if other
-    solvers are required.
+    This method is currently limited to ODE solvers of order 10 or lower.
 """
 function IntegratingGKSumCallback(
         integrand_func, integrand_values::IntegrandValuesSum, integrand_prototype,

--- a/src/integrating_sum.jl
+++ b/src/integrating_sum.jl
@@ -3,7 +3,7 @@
 
 A struct used to save the accumulated integrand value in `integrand::integrandType`.
 
-## Fields
+# Fields
 
   - `integrand::integrandType`: the running quadrature total. The callback mutates this value
     in place for mutable values such as arrays; scalar totals are replaced with the updated
@@ -11,17 +11,17 @@ A struct used to save the accumulated integrand value in `integrand::integrandTy
 
 Do not mutate `integrand` while a solve using this storage is active.
 
-## Constructors
+# Constructors
 
   - `IntegrandValuesSum(initial_value)`: Create with an initial value (recommended).
     The type is inferred from the value. Use `zeros(n)` for arrays or `zero(T)` for scalars.
 
-## Returns
+# Returns
 
 An `IntegrandValuesSum` container for [`IntegratingSumCallback`](@ref) or
 [`IntegratingGKSumCallback`](@ref).
 
-## Examples
+# Examples
 
 ```julia
 # For array-valued integrands
@@ -39,7 +39,7 @@ end
 # and is the recommended API. It correctly infers the type from the value.
 
 """
-    IntegrandValuesSum(integrandType::DataType)
+    IntegrandValuesSum(integrandType::Type)
 
 !!! warning "Deprecated"
     Passing a type is deprecated. Pass a value instead:
@@ -47,6 +47,15 @@ end
     - For arrays: `IntegrandValuesSum(zeros(n))` instead of `IntegrandValuesSum(Vector{T})`
 
 This method is kept for backwards compatibility but will be removed in a future version.
+
+# Returns
+
+  - `IntegrandValuesSum`: scalar storage initialized with `zero(integrandType)`.
+
+# Throws
+
+  - `ArgumentError`: if `integrandType` is not a subtype of `Number`, because its shape
+    cannot be inferred from the type alone.
 """
 function IntegrandValuesSum(::Type{integrandType}) where {integrandType}
     Base.depwarn(

--- a/src/iterative_and_periodic.jl
+++ b/src/iterative_and_periodic.jl
@@ -181,6 +181,8 @@ stops are separated by `Δt` and are offset from the initial time by `phase`. Wh
 # Throws
 
   - `ArgumentError`: if `phase < 0`.
+  - `AssertionError`: during callback initialization if the sign of `Δt` does not match
+    the integration direction.
 
 # Examples
 

--- a/src/manifold.jl
+++ b/src/manifold.jl
@@ -1,7 +1,8 @@
 """
     ManifoldProjection(
         manifold; nlsolve = missing, save = true, autonomous = nothing,
-        manifold_jacobian = nothing, autodiff = nothing, kwargs...)
+        manifold_jacobian = nothing, autodiff = nothing,
+        resid_prototype = nothing, kwargs...) -> DiscreteCallback
 
 In many cases, you may want to declare a manifold on which a solution lives. Mathematically,
 a manifold `M` is defined by a function `g` as the set of points where `g(u) = 0`. An
@@ -18,38 +19,45 @@ conserve properties. If the solution is supposed to live on a specific manifold 
 such property, this guarantees the conservation law without modifying the convergence
 properties.
 
-## Arguments
+# Arguments
 
-  - `manifold`: The residual function for the manifold. If the ODEProblem is an inplace
-    problem, then `g` must be an inplace function of form `g(resid, u, p)` or
-    `g(resid, u, p, t)` and similarly if the ODEProblem is an out-of-place problem then `g`
-    must be a function of form `g(u, p)` or `g(u, p, t)`.
+  - `manifold`: residual function defining the manifold. For an in-place problem, define
+    `manifold(resid, u, p)` or `manifold(resid, u, p, t)`. For an out-of-place problem,
+    define `manifold(u, p)` or `manifold(u, p, t)`. The residual is zero on the manifold.
 
-## Keyword Arguments
+# Keywords
 
-  - `nlsolve`: Defaults to a special single-factorize algorithm (denoted by `missing`) that
-    would work in most cases (See [1] for details). Alternatively, a nonlinear solver as
-    defined in the
+  - `nlsolve = missing`: use the built-in single-factorization projection algorithm. Pass a
+    nonlinear solver in the
     [NonlinearSolve.jl format](https://docs.sciml.ai/NonlinearSolve/stable/basics/solve/)
-    can be specified. Additionally if NonlinearSolve.jl is loaded and `nothing` is specified
-    a polyalgorithm is used.
-  - `save`: Whether to do the standard saving (applied after the callback)
-  - `autonomous`: Whether `g` is an autonomous function of the form `g(resid, u, p)` or
-    `g(u, p)`. Specify it as `Val(::Bool)` to disable runtime branching. If `nothing`,
-    we attempt to infer it from the signature of `g`.
-  - `residual_prototype`: The size of the manifold residual. If it is not specified,
-    we assume it to be same as `u` in the inplace case. Else we run a single evaluation of
-    `manifold` to determine the size.
-  - `kwargs`: All other keyword arguments are passed to
+    to select another algorithm. Pass `nothing` to use the NonlinearSolve polyalgorithm.
+  - `save::Bool = true`: save immediately after the projection.
+  - `autonomous = nothing`: whether `manifold` omits the time argument. Pass `Val(true)`
+    or `Val(false)` to avoid runtime branching; `nothing` infers the form during
+    initialization.
+  - `resid_prototype = nothing`: prototype defining the residual shape for an in-place
+    problem. Without one, the residual is assumed to have the same shape as `u`.
+  - `autodiff = nothing`: DifferentiationInterface automatic-differentiation backend used
+    when `manifold_jacobian` is not supplied.
+  - `manifold_jacobian = nothing`: analytic Jacobian of `manifold` with respect to `u`. Use
+    the same calling form as `manifold`, with the Jacobian output as the first argument for
+    an in-place problem.
+  - `kwargs...`: additional keywords passed to the built-in projection algorithm or to
     [NonlinearSolve.jl](https://docs.sciml.ai/NonlinearSolve/stable/basics/solve/) if
     `nlsolve` is not `missing`.
-  - `autodiff`: The autodifferentiation algorithm to use to compute the Jacobian if
-    `manifold_jacobian` is not specified. This must be specified if `manifold_jacobian` is
-    not specified.
-  - `manifold_jacobian`: The Jacobian of the manifold (wrt the state). This has the same
-    signature as `manifold` and the first argument is the Jacobian if inplace.
 
-### Saveat Warning
+# Returns
+
+  - `DiscreteCallback`: a callback that projects the state after each accepted step. If the
+    nonlinear projection does not converge, the callback terminates the integrator with the
+    projection solver's unsuccessful return code.
+
+# Throws
+
+  - `ErrorException`: during callback initialization if both `manifold_jacobian` and
+    `autodiff` are `nothing`.
+
+# Saveat Warning
 
 Note that the `ManifoldProjection` callback modifies the endpoints of the integration
 intervals and thus breaks assumptions of internal interpolations. Because of this, the
@@ -58,16 +66,16 @@ be proportional to the change by the projection, so if the projection is making 
 changes then one is still safe. However, if there are large changes from each projection,
 you should consider only saving at stopping/projection times. To do this, set `tstops` to
 the same values as `saveat`. There is a performance hit by doing so because now the
-integrator is forced to stop at every saving point, but this is guerenteed to match the
-order of the integrator even with the ManifoldProjection.
+integrator is forced to stop at every saving point, but this is guaranteed to match the
+order of the integrator even with the `ManifoldProjection`.
 
-## References
+# References
 
 [1] Ernst Hairer, Christian Lubich, Gerhard Wanner. Geometric Numerical Integration:
 Structure-Preserving Algorithms for Ordinary Differential Equations. Berlin ;
 New York :Springer, 2002.
 
-## Examples
+# Examples
 
 ```julia
 using ADTypes, DiffEqCallbacks, OrdinaryDiffEq
@@ -82,7 +90,7 @@ function rotation!(du, u, p, t)
 end
 
 prob = ODEProblem(rotation!, [1.0, 0.0], (0.0, 10.0))
-cb = ManifoldProjection(unit_circle; residual_prototype = [0.0], autodiff = AutoFiniteDiff())
+cb = ManifoldProjection(unit_circle; resid_prototype = [0.0], autodiff = AutoFiniteDiff())
 
 sol = solve(prob, Tsit5(); callback = cb)
 ```

--- a/src/probints.jl
+++ b/src/probints.jl
@@ -20,29 +20,33 @@ function (p::ProbIntsCache)(integrator)
 end
 
 """
-```julia
-ProbIntsUncertainty(σ, order, save = true)
-```
+    ProbIntsUncertainty(σ, order, save = true) -> DiscreteCallback
 
 The [ProbInts](https://arxiv.org/abs/1506.04592) method for uncertainty quantification
 involves the transformation of an ODE into an associated SDE where the noise is related to
 the timesteps and the order of the algorithm.
 
-## Arguments
+# Arguments
 
-  - `σ` is the noise scaling factor. It is recommended that `σ` is representative of the size
+  - `σ`: noise scaling factor. It is recommended that `σ` is representative of the size
     of the errors in a single step of the equation. If such a value is unknown, it can be
-    estimated automatically in adaptive time-stepping algorithms via AdaptiveProbIntsUncertainty
-  - `order` is the order of the ODE solver algorithm.
-  - `save` is for choosing whether this callback should control the saving behavior. Generally
-    this is true unless one is stacking callbacks in a `CallbackSet`.
+    estimated automatically in adaptive time-stepping algorithms with
+    [`AdaptiveProbIntsUncertainty`](@ref).
+  - `order::Integer`: order of the ODE solver algorithm.
+  - `save::Bool = true`: whether to save immediately before applying the random
+    perturbation.
 
-## References
+# Returns
+
+  - `DiscreteCallback`: a callback that perturbs the array state after every accepted step.
+    The state must support in-place broadcasting and have a defined `size`.
+
+# References
 
 Conrad P., Girolami M., Särkkä S., Stuart A., Zygalakis. K, Probability
 Measures for Numerical Solutions of Differential Equations, arXiv:1506.04592
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq
@@ -68,9 +72,7 @@ function (p::AdaptiveProbIntsCache)(integrator)
 end
 
 """
-```julia
-AdaptiveProbIntsUncertainty(order, save = true)
-```
+    AdaptiveProbIntsUncertainty(order, save = true) -> DiscreteCallback
 
 The [ProbInts](https://arxiv.org/abs/1506.04592) method for uncertainty quantification
 involves the transformation of an ODE into an associated SDE where the noise is related to
@@ -80,18 +82,28 @@ the timesteps and the order of the algorithm.
 uses the error estimate from within adaptive time stepping methods to estimate `σ` at
 every step.
 
-## Arguments
+# Arguments
 
-  - `order` is the order of the ODE solver algorithm.
-  - `save` is for choosing whether this callback should control the saving behavior. Generally
-    this is true unless one is stacking callbacks in a `CallbackSet`.
+  - `order::Integer`: order of the ODE solver algorithm.
+  - `save::Bool = true`: whether to save immediately before applying the random
+    perturbation.
 
-## References
+# Returns
+
+  - `DiscreteCallback`: a callback that scales its array-state perturbation by the adaptive
+    integrator's current local error estimate after every accepted step.
+
+# Throws
+
+  - An error during callback execution if the integrator does not expose a local error
+    estimate through `EEst` or its controller cache.
+
+# References
 
 Conrad P., Girolami M., Särkkä S., Stuart A., Zygalakis. K, Probability
 Measures for Numerical Solutions of Differential Equations, arXiv:1506.04592
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -4,10 +4,13 @@
 Container used by [`SavingCallback`](@ref) to store saved time points and
 user-defined values.
 
-## Fields
+# Fields
 
   - `t::Vector{tType}`: saved time points.
   - `saveval::Vector{savevalType}`: values returned by the saving function.
+
+Construct empty storage with `SavedValues(tType, savevalType)`. The callback appends to both
+vectors in place; do not mutate them while a solve is active.
 """
 struct SavedValues{tType, savevalType}
     t::Vector{tType}
@@ -17,18 +20,23 @@ end
 """
     SavedValues(tType::Type, savevalType::Type)
 
-Return `SavedValues{tType, savevalType}` with empty storage vectors.
+Construct empty storage for [`SavingCallback`](@ref).
 
-## Arguments
+# Arguments
 
   - `tType`: the element type of saved time points.
   - `savevalType`: the element type of saved values returned by the saving function.
 
-## Example
+# Returns
+
+  - `SavedValues{tType, savevalType}`: storage whose `t` and `saveval` vectors are empty.
+
+# Examples
 
 ```julia
+using DiffEqCallbacks
+
 saved_values = SavedValues(Float64, Tuple{Float64, Float64})
-cb = SavingCallback((u, t, integrator) -> (sum(u), maximum(u)), saved_values)
 ```
 """
 function SavedValues(::Type{tType}, ::Type{savevalType}) where {tType, savevalType}
@@ -140,37 +148,52 @@ function saving_initialize(cb, u, t, integrator)
 end
 
 """
-```julia
-SavingCallback(save_func, saved_values::SavedValues;
-    saveat = Vector{eltype(saved_values.t)}(),
-    save_everystep = isempty(saveat),
-    save_start = true,
-    tdir = 1)
-```
+    SavingCallback(save_func, saved_values::SavedValues;
+        saveat = Vector{eltype(saved_values.t)}(),
+        save_everystep = isempty(saveat),
+        save_start = save_everystep || isempty(saveat) || saveat isa Number,
+        save_end = save_everystep || isempty(saveat) || saveat isa Number,
+        tdir = 1) -> DiscreteCallback
 
 The saving callback lets you define a function `save_func(u, t, integrator)` which
 returns quantities of interest that shall be saved.
 
-## Arguments
+# Arguments
 
-  - `save_func(u, t, integrator)` returns the quantities which shall be saved.
-    Note that this should allocate the output (not as a view to `u`).
-  - `saved_values::SavedValues` is the types that `save_func` will return, i.e.
-    `save_func(t, u, integrator)::savevalType`. It's specified via
-    `SavedValues(typeof(t),savevalType)`, i.e. give the type for time and the
-    type that `save_func` will output (or higher compatible type).
+  - `save_func`: function called as `save_func(u, t, integrator)`. It must return a value
+    compatible with `eltype(saved_values.saveval)` and must not return a view of `u`.
+  - `saved_values::SavedValues`: storage whose time and value element types match the
+    integration time and the output of `save_func`.
 
-## Keyword Arguments
+# Keywords
 
-  - `saveat` mimics `saveat` in `solve` from `solve`.
-  - `save_everystep` mimics `save_everystep` from `solve`.
-  - `save_start` mimics `save_start` from `solve`.
-  - `save_end` mimics `save_end` from `solve`.
-  - `tdir` should be `sign(tspan[end]-tspan[1])`. It defaults to `1` and should
-    be adapted if `tspan[1] > tspan[end]`.
+  - `saveat = Vector{eltype(saved_values.t)}()`: selected integration times, or a scalar
+    interval at which to evaluate `save_func` throughout the problem time span.
+  - `save_everystep::Bool = isempty(saveat)`: whether to save after every accepted step.
+  - `save_start::Bool = ...`: whether to save at the initial condition.
+  - `save_end::Bool = ...`: whether to save at the final time.
+  - `tdir = 1`: integration direction used to order `saveat`. Set this to
+    `sign(tspan[end] - tspan[1])` for reverse-time problems.
 
-The outputted values are saved into `saved_values`. Time points are found via
+The output values are saved into `saved_values`. Time points are found via
 `saved_values.t` and the values are `saved_values.saveval`.
+
+# Returns
+
+  - `DiscreteCallback`: a callback that evaluates `save_func` at the requested times and
+    appends the results to `saved_values`.
+
+# Examples
+
+```julia
+using DiffEqCallbacks, OrdinaryDiffEq
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+saved_values = SavedValues(Float64, Float64)
+cb = SavingCallback((u, t, integrator) -> u^2, saved_values; saveat = 0.0:0.25:1.0)
+
+sol = solve(prob, Tsit5(); callback = cb)
+```
 """
 function SavingCallback(
         save_func, saved_values::SavedValues;
@@ -374,8 +397,8 @@ function with_cache(f::Function, cache::CachePool{T}) where {T}
 end
 
 """
-    LinearizingSavingCallback(ils::IndependentlyLinearizedSolution)
-    LinearizingSavingCallback(ilss::Vector{IndependentlyLinearizedSolution})
+    LinearizingSavingCallback(ils::IndependentlyLinearizedSolution;
+        kwargs...) -> DiscreteCallback
 
 Return a saving callback that inserts interpolation points so that linear interpolation
 of the saved values is within `abstol`/`reltol` of the integrator interpolation.
@@ -385,30 +408,31 @@ goodness of fit versus the linearly interpolated function; this should be suffic
 interpolations up to the 4th order, higher orders may need more points to ensure good
 fit.  This has not been implemented yet.
 
-## Arguments
+# Arguments
 
   - `ils`: the [`IndependentlyLinearizedSolution`](@ref) storage object to fill.
-  - `ilss`: storage objects for multiple independently linearized solutions.
+# Keywords
 
-## Keyword Arguments
-
-  - `interpolate_mask`: a `BitVector` selecting the `u` indices for which the
+  - `interpolate_mask::BitVector`: select the state indices for which the
     integrator interpolant can be queried. False indices are linearly interpolated
-    from the solution time points without subdivision.
-  - `abstol`: absolute tolerance for comparing linearized and integrator interpolation.
-    Defaults to the integrator absolute tolerance.
-  - `reltol`: relative tolerance for comparing linearized and integrator interpolation.
-    Defaults to the integrator relative tolerance.
+    from the solution time points without subdivision. By default, all indices are selected.
+  - `abstol = nothing`: absolute tolerance for comparing linearized and integrator
+    interpolation. Defaults to the integrator absolute tolerance.
+  - `reltol = nothing`: relative tolerance for comparing linearized and integrator
+    interpolation. Defaults to the integrator relative tolerance.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that stores independently linearized output in `ils`.
+  - `DiscreteCallback`: a callback that stores independently linearized output in `ils`.
 
-## Example
+# Examples
 
 ```julia
+using DiffEqCallbacks, OrdinaryDiffEq
+
+prob = ODEProblem((du, u, p, t) -> (du .= -u), [1.0, 2.0], (0.0, 1.0))
 ils = IndependentlyLinearizedSolution(prob)
-sol = solve(prob, solver; callback = LinearizingSavingCallback(ils))
+sol = solve(prob, Tsit5(); callback = LinearizingSavingCallback(ils))
 ```
 """
 function LinearizingSavingCallback(

--- a/src/stepsizelimiters.jl
+++ b/src/stepsizelimiters.jl
@@ -28,7 +28,7 @@ end
 
 """
     StepsizeLimiter(dtFE; safety_factor = 9 // 10, max_step = false,
-        cached_dtcache = 0.0)
+        cached_dtcache = 0.0) -> DiscreteCallback
 
 In many cases, there is a known maximal stepsize for which the computation is
 stable and produces correct results. For example, in hyperbolic PDEs one normally
@@ -38,24 +38,23 @@ by the CFL condition. For nonlinear hyperbolic PDEs this limit can be a function
 you pass a function which will adaptively limit the stepsizes to match these
 constraints.
 
-## Arguments
+# Arguments
 
-- `dtFE` is the maximal timestep and is calculated using the previous `t` and `u`.
+  - `dtFE`: function called as `dtFE(u, p, t)` to compute the current maximum stable step.
 
-## Keyword Arguments
+# Keywords
 
-- `safety_factor` is the factor below the true maximum that will be stepped to
-  which defaults to `9//10`.
-- `max_step=true` makes every step equal to `safety_factor*dtFE(u,p,t)` when the
-  solver is set to `adaptive=false`.
-- `cached_dtcache` should be set to match the type for time when not using
-  Float64 values.
+  - `safety_factor = 9 // 10`: factor applied to the maximum returned by `dtFE`.
+  - `max_step::Bool = false`: when `true`, set every proposed step to
+    `safety_factor * dtFE(u, p, t)`, including for a non-adaptive solver.
+  - `cached_dtcache = 0.0`: initial cache for the unconstrained step. Set it to a value with
+    the problem time type when that type is not `Float64`.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that updates `integrator.opts.dtmax` before every step.
+  - `DiscreteCallback`: a callback that updates `integrator.opts.dtmax` before every step.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/src/terminatesteadystate.jl
+++ b/src/terminatesteadystate.jl
@@ -56,37 +56,39 @@ end
 # test function must take integrator, time, followed by absolute
 #   and relative tolerance and return true/false
 """
-    TerminateSteadyState(abstol = 1e-8, reltol = 1e-6, test = allDerivPass; min_t = nothing,
-        wrap_test::Val = Val(true))
+    TerminateSteadyState(abstol = 1.0e-8, reltol = 1.0e-6, test = allDerivPass;
+        min_t = nothing, wrap_test::Val = Val(true)) -> DiscreteCallback
 
 `TerminateSteadyState` can be used to solve the problem for the steady-state
 by running the solver until the derivatives of the problem converge to 0 or
-`tspan[2]` is reached. This is an alternative approach to root finding (see
-the [Steady State Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/steady_state_solve/) section).
+`tspan[2]` is reached. This is an alternative approach to root finding; see the
+[Steady State Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/steady_state_solve/)
+documentation.
 
-## Arguments
+# Arguments
 
-  - `abstol` and `reltol` are the absolute and relative tolerance, respectively.
-    These tolerances may be specified as scalars or as arrays of the same length
-    as the states of the problem.
-  - `test` represents the function that evaluates the condition for termination. The default
-    condition is that all derivatives should become smaller than `abstol` or the states times
-    `reltol`. The user can pass any other function to implement a different termination condition.
-    Such function should take four arguments: `integrator`, `abstol`, `reltol`, and `min_t`.
-  - `wrap_test` can be set to `Val(false)`, in which case `test` must have the definition
-    `test(u, t, integrator)`. Otherwise, `test` must have the definition
-    `test(integrator, abstol, reltol, min_t)`.
+  - `abstol = 1.0e-8`: absolute termination tolerance. It may be a scalar or an array with
+    the same length as the state.
+  - `reltol = 1.0e-6`: relative termination tolerance. It may be a scalar or an array with
+    the same length as the state.
+  - `test = allDerivPass`: function that evaluates the termination condition. By default,
+    every derivative must be smaller than `abstol` or the corresponding state magnitude
+    times `reltol`. A custom wrapped test must accept `integrator`, `abstol`, `reltol`, and
+    `min_t`.
 
-## Keyword Arguments
+# Keywords
 
-  - `min_t` specifies an optional minimum `t` before the steady state calculations are allowed
-    to terminate.
+  - `min_t = nothing`: optional minimum integration time before termination is allowed.
+  - `wrap_test::Val = Val(true)`: with `Val(true)`, call `test` as
+    `test(integrator, abstol, reltol, min_t)`. With `Val(false)`, use `test` directly as the
+    callback condition `test(u, t, integrator)`.
 
-## Returns
+# Returns
 
-A `DiscreteCallback` that terminates the integrator when `test` returns `true`.
+  - `DiscreteCallback`: a callback that terminates the integrator when `test` returns
+    `true`.
 
-## Examples
+# Examples
 
 ```julia
 using DiffEqCallbacks, OrdinaryDiffEq

--- a/test/independentlylinearizedtests.jl
+++ b/test/independentlylinearizedtests.jl
@@ -126,4 +126,10 @@ display(@benchmark sample(ils, many_ts))
     finish!(ils, ReturnCode.Default)
     @test sample(ils, ils.ts) == repeat(1:num_timepoints, 1, num_us)
     @test sample(ils, ils.ts, 1) == 2 * repeat(1:num_timepoints, 1, num_us)
+
+    first_t, first_values = first(ils)
+    @test first_t == 1.0
+    @test size(first_values) == (num_us, num_derivatives + 1)
+    @test first_values[:, 1] == fill(1.0, num_us)
+    @test first_values[:, 2] == fill(2.0, num_us)
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- complete SciMLStyle definition-site documentation for all 22 owned exported names, including exact calling forms, arguments, keywords, return contracts, failure modes, and runnable examples
- correct inaccurate public documentation for domain, manifold, integrating, saving, probabilistic, and termination callbacks without changing runtime behavior or exports
- document the generic iteration contract of `IndependentlyLinearizedSolution` and add focused tests for its yielded `(t, values)` shape and contents

## Audit process

- inspected the current open pull requests and synced from `SciML/DiffEqCallbacks.jl` `master` before creating the feature branch
- ran clean-base release and Julia 1.10 package and strict-QA tests before editing
- audited every owned export for definition-site documentation and rendered `@docs` coverage; all 22 are attached and rendered
- kept the change to docstrings plus one interface-contract test; no source-path metadata, blanket reexports, QA suppressions, or test disabling were added
- retained `SciMLTesting = "2.4"` compatibility in both test environments

## Local validation

- `Runic --check .`: exit 0, no output
- `git diff --check`: exit 0, no output
- Julia 1.12.6 / release `Pkg.test()`: all callback groups passed; `Testing DiffEqCallbacks tests passed`
- Julia 1.12.6 / release `GROUP=QA Pkg.test()`: `QA/jet_tests.jl` 15/15 and `QA/qa.jl` 22/22; passed
- Julia 1.10.11 `Pkg.test()`: all callback groups passed; `Testing DiffEqCallbacks tests passed`
- Julia 1.10.11 `GROUP=QA Pkg.test()`: existing LTS JET marker `Broken 1/1`, `QA/qa.jl` 20/20; passed
- Documenter build on Julia 1.12.6: exit 0 after retrying the initial one-hour HTML serialization timeout with a two-hour timeout; doctests, cross-references, document checks, and HTML rendering completed

