### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,52 @@
+using DiffEqCallbacks, OrdinaryDiffEq, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Simple decay problem
+f_decay!(du, u, p, t) = (du .= -u)
+prob = ODEProblem(f_decay!, ones(5), (0.0, 10.0))
+
+# =============================================================================
+# Event callbacks
+# =============================================================================
+
+SUITE["callbacks"] = BenchmarkGroup()
+
+# ContinuousCallback: root-finding when u[1] crosses 0.5
+condition(u, t, integrator) = u[1] - 0.5
+function affect!(integrator)
+    return integrator.u[1] += 0.1
+end
+cb_cont = ContinuousCallback(condition, affect!)
+SUITE["callbacks"]["continuous"] = @benchmarkable solve(
+    $prob, Tsit5(); callback = $cb_cont
+)
+
+# PresetTimeCallback
+function preset_affect!(integrator)
+    return integrator.u .+= 0.1
+end
+cb_preset = PresetTimeCallback([2.0, 5.0, 8.0], preset_affect!)
+SUITE["callbacks"]["preset_time"] = @benchmarkable solve(
+    $prob, Tsit5(); callback = $cb_preset
+)
+
+# TerminateSteadyState
+cb_term = TerminateSteadyState(1.0e-8)
+SUITE["callbacks"]["terminate_steady"] = @benchmarkable solve(
+    $prob, Tsit5(); callback = $cb_term
+)
+
+# SavingCallback with SavedValues
+saved = SavedValues(Float64, Vector{Float64})
+save_fn(u, t, integrator) = copy(u)
+cb_save = SavingCallback(save_fn, saved; saveat = 0:0.1:10)
+SUITE["callbacks"]["saving"] = @benchmarkable solve(
+    $prob, Tsit5(); callback = $cb_save
+)
+
+# PeriodicCallback
+cb_periodic = PeriodicCallback(preset_affect!, 1.0)
+SUITE["callbacks"]["periodic"] = @benchmarkable solve(
+    $prob, Tsit5(); callback = $cb_periodic
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~28s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~28s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md