### PR TITLE
Import `adjoint` and `copyto!` from `Base` rather than `LinearAlgebra`

### DIFF
--- a/src/DiffEqCallbacks.jl
+++ b/src/DiffEqCallbacks.jl
@@ -4,7 +4,8 @@ using ConcreteStructs: @concrete
 using DataStructures: DataStructures, BinaryMaxHeap, BinaryMinHeap
 using DiffEqBase: get_tstops, get_tstops_array, get_tstops_max
 using DifferentiationInterface: DifferentiationInterface, Constant
-using LinearAlgebra: LinearAlgebra, adjoint, axpy!, copyto!, diagind, mul!
+using Base: adjoint, copyto!
+using LinearAlgebra: LinearAlgebra, axpy!, diagind, mul!
 using PrecompileTools: PrecompileTools
 using RecipesBase: @recipe
 using RecursiveArrayTools: RecursiveArrayTools, DiffEqArray, copyat_or_push!


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) fails two ExplicitImports checks because `adjoint` and `copyto!` are imported from `LinearAlgebra`, while their owner is `Base`:

- `all_explicit_imports_via_owners`: `` `adjoint`/`copyto!` have owner `Base` but were imported from `LinearAlgebra` ``
- `all_explicit_imports_are_public`: `` `adjoint`/`copyto!` are not public in `LinearAlgebra` ``

Failing run: https://github.com/SciML/DiffEqCallbacks.jl/actions/runs/34655431845

They are now imported from `Base`. `axpy!`, `diagind`, and `mul!` are still owned by `LinearAlgebra` and stay in that import.

## Test plan

- [x] `test/qa/qa.jl` passes 20/20 on Julia 1.13.0 (the two EI checks errored in CI on the unfixed code)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`