### PR TITLE
Release DiffEqCallbacks 4.19.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqCallbacks"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.19.3"
+version = "4.19.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `DiffEqCallbacks` 4.19.3 -> 4.19.4 (patch).

Source files changed since 4.19.3:
- `src/DiffEqCallbacks.jl`

Commits:
- Drop stale [compat] majors older than one year (#341)
- compat: drop the unregistered SafeTestsets 1.x major (#342)
- Add 32-bit Core CI lane via test_groups.toml (#343)
- Add AirspeedVelocity benchmarking CI (#344)
- Import `adjoint` and `copyto!` from `Base` rather than `LinearAlgebra` (#345)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
